### PR TITLE
Removed windup from the product name, as it's also in the book title.

### DIFF
--- a/docs/Windup-Core-Development-Guide-docinfo.xml
+++ b/docs/Windup-Core-Development-Guide-docinfo.xml
@@ -1,5 +1,5 @@
 <title>Windup Core Development Guide</title>
-<productname>Red Hat JBoss Migration Toolkit - Windup</productname>
+<productname>Red Hat JBoss Migration Toolkit</productname>
 <productnumber>2.3</productnumber>
 <subtitle>Contribute to the Windup Code Base</subtitle>
 <abstract>

--- a/docs/Windup-Rules-Development-Guide-docinfo.xml
+++ b/docs/Windup-Rules-Development-Guide-docinfo.xml
@@ -1,5 +1,5 @@
 <title>Windup Rules Development Guide</title>
-<productname>Red Hat JBoss Migration Toolkit - Windup</productname>
+<productname>Red Hat JBoss Migration Toolkit</productname>
 <productnumber>2.3</productnumber>
 <subtitle>Create Custom Rules for Windup</subtitle>
 <abstract>

--- a/docs/Windup-User-Guide-docinfo.xml
+++ b/docs/Windup-User-Guide-docinfo.xml
@@ -1,5 +1,5 @@
 <title>Windup User Guide</title>
-<productname>Red Hat JBoss Migration Toolkit - Windup</productname>
+<productname>Red Hat JBoss Migration Toolkit</productname>
 <productnumber>2.3</productnumber>
 <!--
 <mediaobject>


### PR DESCRIPTION
Removed the " - Windup" suffix from the productname, as it ends up becoming duplicated. ie: Red Hat JBoss Migration Toolkit - Windup 2.3 Windup User Guide