### PR TITLE
tweaks to eclipse plugin guide

### DIFF
--- a/docs/windup-plugin-guide/windup-eclipse-plugin-guide-early-access.html
+++ b/docs/windup-plugin-guide/windup-eclipse-plugin-guide-early-access.html
@@ -452,24 +452,12 @@ This is an early access version of this guide.
 <div class="title">Supported Development Environments</div>
 <ul>
 <li>
-<p>Eclipse 4.6 (Neon) or later</p>
+<p>Eclipse 4.6 (Neon)</p>
 </li>
 <li>
-<p>Red Hat JBoss Developer Studio 10 or later</p>
+<p>Red Hat JBoss Developer Studio 10.1</p>
 </li>
 </ul>
-</div>
-<div class="admonitionblock note">
-<table>
-<tr>
-<td class="icon">
-<div class="title">Note</div>
-</td>
-<td class="content">
-These instructions use Eclipse 4.6 (Neon). Your steps may vary if you are using JBoss Developer Studio or a different version of Eclipse.
-</td>
-</tr>
-</table>
 </div>
 <div class="olist arabic">
 <div class="title">Install the Plugin</div>


### PR DESCRIPTION
-- Narrow supported environments text to only specify Eclipse Neon and DevStudio 10.1 (should work with earlier or later minor versions but nothing else has been tested.) 

-- Remove note about instructions varying on DevStudio/other. I've tested these instructions on DevStudio 10.1 and everything works as expected. (Alternatively, we could replace this with a note about how the same instructions should apply for later versions of Eclipse/DevStudio or other minor releases of DevStudio 10, but have not been tested -- though maybe there's no point in saying that if we're not calling them out as supported. Let me know what you think.)