### PR TITLE
WINDUP-2107: Corrected maven version.

### DIFF
--- a/docs/topics/templates/document-attributes.adoc
+++ b/docs/topics/templates/document-attributes.adoc
@@ -59,7 +59,7 @@
 // :ProductVersion: 4.0
 :ProductDistributionVersion: 4.1.0.Final
 :ProductDistribution: rhamt-cli-{ProductDistributionVersion}
-:MavenProductVersion: 4.1.0-Final
+:MavenProductVersion: 4.1.0.Final
 
 // ********
 // * URLs *


### PR DESCRIPTION
Corrected the Maven version to be `4.1.0.Final` in the document-attributes.adoc file. This now renders correctly.