### PR TITLE
Corrected download link.

### DIFF
--- a/docs/topics/templates/document-attributes.adoc
+++ b/docs/topics/templates/document-attributes.adoc
@@ -82,7 +82,7 @@
 :ProductDocCoreGuideURL: https://github.com/windup/windup/wiki/Core-Development-Guide
 
 // URL for downloads on developers.redhat.com
-:ProductDownloadURL: https://developers.redhat.com/download-manager/file/{ProductVersion}/
+:ProductDownloadURL: https://developers.redhat.com/download-manager/file/
 
 // *********
 // * Icons *


### PR DESCRIPTION
This is a cherry pick of 1c0803f5c3639e8edbf7e50c9296e0bef92867ea for the 4.2.x branch.