### PR TITLE
WINDUP-2484: 4.3.0 updates to the IDE Plugin Guide

### DIFF
--- a/docs/plugin-guide/master-docinfo.xml
+++ b/docs/plugin-guide/master-docinfo.xml
@@ -1,7 +1,7 @@
 <title>{PluginBookName}</title>
 <productname>{DocInfoProductName}</productname>
 <productnumber>{DocInfoProductNumber}</productnumber>
-<subtitle>Identify and resolve migration issues by running the Red Hat Application Migration Toolkit against your applications in Eclipse.</subtitle>
+<subtitle>Identify and resolve migration issues by running the Red Hat Application Migration Toolkit against your applications in your IDE.</subtitle>
 <abstract>
     <para>This guide describes how to use the {ProductName} {PluginName} to simplify migration of Java applications.</para>
 </abstract>

--- a/docs/plugin-guide/master.adoc
+++ b/docs/plugin-guide/master.adoc
@@ -26,7 +26,7 @@ include::topics/plugin-supported-configs.adoc[leveloffset=+2]
 // Install the IDE Plugin
 include::topics/plugin-install.adoc[leveloffset=+1]
 
-// Access the {ProductShortName} Eclipse Tools
+// Access the {ProductShortName} IDE Tools
 include::topics/plugin-access-windup-tools.adoc[leveloffset=+1]
 
 // Windup IDE Plugin Components

--- a/docs/topics/about-plugin.adoc
+++ b/docs/topics/about-plugin.adoc
@@ -1,7 +1,7 @@
 [[about_the_plugin]]
 = About the {PluginNameTitle}
 
-The {PluginName} for {ProductName} provides assistance directly in Eclipse and Red Hat CodeReady Studio for developers making changes for a migration or modernization effort.  It analyzes your projects using {ProductShortName}, marks migration issues in the source code, provides guidance to fix the issues, and offers automatic code replacement when possible.
+The {PluginName} for {ProductName} provides assistance directly in Eclipse and Red Hat CodeReady Studio for developers making changes for a migration or modernization effort. It analyzes your projects using {ProductShortName}, marks migration issues in the source code, provides guidance to fix the issues, and offers automatic code replacement when possible.
 
 A {ProductName} extension is also available for Visual Studio Code and Eclipse Che.
 The 4.3.0 product release introduces a Minimum Viable Product version of a RHAMT extension that contains all of the core features required to perform a RHAMT analysis within an IDE.

--- a/docs/topics/install-jboss-tools.adoc
+++ b/docs/topics/install-jboss-tools.adoc
@@ -3,9 +3,11 @@
 
 The {PluginNameTitle} depends on JBoss Tools, and therefore these dependencies must be installed for {ProductShortName} to function successfully. The following instructions detail installing JBoss Tools on an Eclipse installation.
 
+NOTE: If you are using Red Hat CodeReady Studio, and not Eclipse, you do not need to install JBoss Tools separately. 
+
 .Install JBoss Tools
 
-. From the menu bar, select *Help* -> *Eclipse Marketplace*. 
+. From the menu bar, select *Help* -> *Eclipse Marketplace*.
 . In the *Find* field, enter `JBoss Tools` and press *Enter* to search for the project.
 . Scroll down until you see *JBoss Tools* in the list and press *Install* next to this project.
 . Review the selected features and press *Confirm*. It is recommended to accept the defaults to install the required dependencies for {ProductShortName}.

--- a/docs/topics/known_issues.adoc
+++ b/docs/topics/known_issues.adoc
@@ -13,8 +13,8 @@ At the time of the release the following known issues have been identified as im
 .Known Issues
 [cols="20%,20%,60%",options="header"]
 |====
-|ID 
-|Component 
+|ID
+|Component
 |Summary
 
 |link:https://issues.jboss.org/browse/WINDUP-2333[WINDUP-2333]

--- a/docs/topics/plugin-access-windup-tools.adoc
+++ b/docs/topics/plugin-access-windup-tools.adoc
@@ -1,6 +1,6 @@
 [[access_windup_features]]
-= Access the {ProductShortName} Eclipse Tools
+= Access the {ProductShortName} IDE Tools
 
-Once the plugin is installed, the {ProductShortName} Eclipse tools are available in the {ProductShortName} perspective. To open the {ProductShortName} perspective, navigate to *Window* -> *Perspective* -> *Open Perspective* -> *Other*. Select *{ProductShortName}* and press *OK*.
+Once the plugin is installed, the {ProductShortName} IDE tools are available in the {ProductShortName} perspective. To open the {ProductShortName} perspective, navigate to *Window* -> *Perspective* -> *Open Perspective* -> *Other*. Select *{ProductShortName}* and press *OK*.
 
-Review the xref:plugin_components[plugin components] and then get started xref:identify_resolve_migration_issues[identifying and resolving migration issues]. You can also view the embedded help for the plugin by selecting *Help* -> *Getting Started* in Eclipse.
+Review the xref:plugin_components[plugin components] and then get started xref:identify_resolve_migration_issues[identifying and resolving migration issues]. You can also view the embedded help for the plugin by selecting *Help* -> *Getting Started* in your IDE.

--- a/docs/topics/plugin-identify-resolve-issues.adoc
+++ b/docs/topics/plugin-identify-resolve-issues.adoc
@@ -3,7 +3,7 @@
 
 Follow these steps to use the {PluginName} to identify and resolve migration issues.
 
-. Import the project to analyze into Eclipse.
+. Import the project to analyze into your IDE.
 . xref:create_run_config[Create a run configuration]. From the Issue Explorer, press the {ProductShortName} button (image:windup.png[{ProductShortName} button]).
 +
 image::windup_button_create_config.png[Select {ProductShortName} button]

--- a/docs/topics/plugin-install.adoc
+++ b/docs/topics/plugin-install.adoc
@@ -11,7 +11,7 @@ If you do not already have an existing installation, download link:http://www.ec
 --
 This guide uses _IDE_ to refer to an installation of Eclipse or Red Hat Red Hat CodeReady Studio.
 
-{ProductShortName} extensions are also available for Visual Studio Code Eclipse Che.
+{ProductShortName} extensions are also available for Visual Studio Code and Eclipse Che.
 A Minimum Viable Product release of these extensions is provided in this release of {RHAMT}, and the extesions are not supported for use in production environments.
 
 You can find more information about link:https://marketplace.visualstudio.com/items?itemName=redhat.rhamt-vscode-extension[the extension] on the Visual Studio Marketplace.

--- a/docs/topics/plugin-install.adoc
+++ b/docs/topics/plugin-install.adoc
@@ -5,9 +5,18 @@ Review the xref:supported_configs[supported configurations] to make sure that yo
 
 NOTE: If you are running macOS, it is recommended to set the maximum number of user processes, `maxproc`, to at least `2048`, and the maximum number of open files, `maxfiles`, to `100000`.
 
-If you do not already have an existing installation, download link:http://www.eclipse.org/downloads/[Eclipse] or link:https://developers.redhat.com/products/devstudio/download/[Red Hat CodeReady Studio] and install it.
+If you do not already have an existing installation, download link:http://www.eclipse.org/downloads/[Eclipse] or link:https://developers.redhat.com/products/codeready-studio/download/[Red Hat CodeReady Studio] and install it.
 
-NOTE: This guide uses _Eclipse_ to refer to an installation of Eclipse or Red Hat CodeReady Studio.
+[NOTE]
+--
+This guide uses _IDE_ to refer to an installation of Eclipse or Red Hat Red Hat CodeReady Studio.
+
+{ProductShortName} extensions are also available for Visual Studio Code Eclipse Che.
+A Minimum Viable Product release of these extensions is provided in this release of {RHAMT}, and the extesions are not supported for use in production environments.
+
+You can find more information about link:https://marketplace.visualstudio.com/items?itemName=redhat.rhamt-vscode-extension[the extension] on the Visual Studio Marketplace.
+--
+
 
 .Prerequisites
 
@@ -24,12 +33,12 @@ NOTE: This guide uses _Eclipse_ to refer to an installation of Eclipse or Red Ha
 .. Select all of the checkboxes under *JBoss Tools - RHAMT* and press *Next*.
 . Review the installation details and press *Next*.
 . Accept the terms of the license agreement and press *Finish* to install the plugin.
-. Restart Eclipse for the changes to take effect.
+. Restart your IDE for the changes to take effect.
 
 .Install the Plugin for an Offline Environment
 
-. Download the link:{ProductDownloadURL}{EclipsePluginFilename}-{ProductVersion}.zip[IDE Plugin Repository].
-. Launch Eclipse.
+. Download the link:{ProductDownloadURL}{IDEPluginFilename}-{ProductVersion}.zip[IDE Plugin Repository].
+. Launch your IDE.
 . From the menu bar, select *Help* -> *Install New Software*.
 . Add the {ProductShortName} update site.
 .. Next to the *Work with* field, click *Add*.
@@ -39,4 +48,4 @@ NOTE: This guide uses _Eclipse_ to refer to an installation of Eclipse or Red Ha
 .. Select all of the checkboxes under *JBoss Tools - RHAMT* and press *Next*.
 . Review the installation details and press *Next*.
 . Accept the terms of the license agreement and press *Finish* to install the plugin.
-. Restart Eclipse for the changes to take effect.
+. Restart your IDE for the changes to take effect.

--- a/docs/topics/plugin-supported-configs.adoc
+++ b/docs/topics/plugin-supported-configs.adoc
@@ -3,5 +3,5 @@
 
 The {PluginName} is tested in following development environments.
 
-* Eclipse 4.8 (Photon)
-* Red Hat CodeReady Studio 12.9
+* Eclipse 2019-09
+* Red Hat CodeReady Studio 12.13

--- a/docs/topics/plugin-uninstall.adoc
+++ b/docs/topics/plugin-uninstall.adoc
@@ -1,10 +1,10 @@
 [[uninstall_plugin]]
 = Uninstall the {PluginNameTitle}
 
-. From Eclipse, navigate to *Help* -> *Installation Details*.
+. From your IDE, navigate to *Help* -> *Installation Details*.
 . In the *Installed Software* tab, select *Windup Feature* and *Windup Feature Developer Resources*.
 +
 Hold the *Ctrl* key to select multiple rows.
 . Select *Uninstall*.
 . Review the details and click *Finish* to uninstall the plugin.
-. Restart Eclipse for the changes to take effect.
+. Restart your IDE for the changes to take effect.

--- a/docs/topics/templates/document-attributes.adoc
+++ b/docs/topics/templates/document-attributes.adoc
@@ -24,7 +24,7 @@
 :PluginName: IDE Plugin
 :PluginNameTitle: IDE Plugin
 
-:EclipsePluginFilename: migrationtoolkit-rhamt-eclipse-plugin-repository
+:IDEPluginFilename: migrationtoolkit-rhamt-eclipse-plugin-repository
 
 :MavenName: Maven plugin
 :MavenNameTitle: Maven Plugin
@@ -37,8 +37,8 @@
 :DocInfoProductNumber: 4.3
 :DocInfoProductNameURL: red_hat_application_migration_toolkit
 
-:OpenShiftProductNumber: 3.11
-:ProductVersion: 4.3.0
+:OpenShiftProductNumber: 3.9
+:ProductVersion: 4.2.1
 
 :UserCLIBookName: CLI Guide
 :RulesDevBookName: Rules Development Guide
@@ -61,7 +61,7 @@
 // :ProductVersion: 4.0
 :ProductDistributionVersion: 4.3.0.Final
 :ProductDistribution: rhamt-cli-{ProductDistributionVersion}
-:MavenProductVersion: 4.3.0.Final
+:MavenProductVersion: 4.2.1.Final
 
 // ********
 // * URLs *

--- a/docs/topics/templates/document-attributes.adoc
+++ b/docs/topics/templates/document-attributes.adoc
@@ -69,7 +69,7 @@
 
 :ProductDocUserGuideURL: https://access.redhat.com/documentation/en-us/{DocInfoProductNameURL}/{DocInfoProductNumber}/html-single/cli_guide
 :ProductDocRulesGuideURL: https://access.redhat.com/documentation/en-us/{DocInfoProductNameURL}/{DocInfoProductNumber}/html-single/rules_development_guide
-:ProductDocPluginGuideURL: https://access.redhat.com/documentation/en-us/{DocInfoProductNameURL}/{DocInfoProductNumber}/html-single/eclipse_plugin_guide
+:ProductDocPluginGuideURL: https://access.redhat.com/documentation/en-us/{DocInfoProductNameURL}/{DocInfoProductNumber}/html-single/ide_plugin_guide
 :ProductDocGettingStartedGuideURL: https://access.redhat.com/documentation/en-us/{DocInfoProductNameURL}/{DocInfoProductNumber}/html-single/getting_started_guide
 :ProductDocWebConsoleGuideURL: https://access.redhat.com/documentation/en-us/{DocInfoProductNameURL}/{DocInfoProductNumber}/html-single/web_console_guide
 :ProductDocMavenGuideURL: https://access.redhat.com/documentation/en-us/{DocInfoProductNameURL}/{DocInfoProductNumber}/html-single/maven_plugin_guide


### PR DESCRIPTION
This PR changes URL fragment from eclipse_plugin_guide to ide_plugin_guide

The title needs to be renamed in Pantheon to ensure builds work