### PR TITLE
Browser support and IE known issue for MTA 5.0

### DIFF
--- a/docs/topics_5/rn-known-issues.adoc
+++ b/docs/topics_5/rn-known-issues.adoc
@@ -12,6 +12,10 @@ At the time of release, the following known issues are identified as major issue
 |Component
 |Summary
 
+|link:https://issues.redhat.com/browse/WINDUP-2683[WINDUP-2683]
+|Web UI & Windup-as-a-Service
+|MTA 5.0 does not support Internet Explorer.
+
 |link:https://issues.redhat.com/browse/WINDUP-2704[WINDUP-2704]
 |Web UI & Windup-as-a-Service
 |On macOS, the `run_mta.sh` script sets the soft limit of open files to `100000`.

--- a/docs/topics_5/web-install-zip.adoc
+++ b/docs/topics_5/web-install-zip.adoc
@@ -5,10 +5,7 @@
 
 You can install the {ProductShortName} {WebName} on a Linux, Windows, or macOS operating system and access the {WebName} in a browser.
 
-[NOTE]
-====
-Windows Internet Explorer is not a supported browser. link:https://issues.redhat.com/browse/WINDUP-2683[WINDUP-2683]
-====
+The {WebName} has been tested with Chrome and Firefox. 
 
 .Prerequisites
 


### PR DESCRIPTION
MTA 5.0 does not support IE (added to known issues). Was tested against Chrome and Firefox (added to installation prerequisites). 