### PR TITLE
Known issue (WINDUP-2710) added for MTA 5.0.0

### DIFF
--- a/docs/topics_5/rn-known-issues.adoc
+++ b/docs/topics_5/rn-known-issues.adoc
@@ -12,6 +12,10 @@ At the time of release, the following known issues are identified as major issue
 |Component
 |Summary
 
+|link:https://issues.redhat.com/browse/WINDUP-2710[WINDUP-2710]
+|Lifecycle (Runtime)
+|Om RHEL CSB, MTA web console 5.0.0 fails after artifact upload.
+
 |link:https://issues.redhat.com/browse/WINDUP-2683[WINDUP-2683]
 |Web UI & Windup-as-a-Service
 |MTA 5.0 does not support Internet Explorer.


### PR DESCRIPTION
Adds https://issues.redhat.com/browse/WINDUP-2710 to top of known issues list for MTA version 5.0.0. 