### PR TITLE
Changes for MTA 5.0.1

### DIFF
--- a/docs/topics_5/cli-prerequisites.adoc
+++ b/docs/topics_5/cli-prerequisites.adoc
@@ -8,13 +8,6 @@
 * OpenJDK 1.8, OpenJDK 11, Oracle JDK 1.8, Oracle JDK 11
 * 8 GB RAM
 
-{CLIName} on macOS has the following additional prerequisites:
+{CLIName} on macOS has the following additional prerequisite:
 
 * Set the `maxproc` value to `2048` or greater.
-
-ifeval::["{ProductVersion}" == "5.0.0"]
-* Set the `maxfiles` value to `10000`.
-endif::[]
-ifeval::["{ProductVersion}" != "5.0.0"]
-* Set the `maxfiles` value to `100000`.
-endif::[]

--- a/docs/topics_5/maven-prerequisites.adoc
+++ b/docs/topics_5/maven-prerequisites.adoc
@@ -9,7 +9,6 @@
 * 8 GB RAM
 * Maven 3.2.5 or later
 
-{MavenName} on macOS has the following additional prerequisites:
+{MavenName} on macOS has the following additional prerequisite:
 
 * Set the `maxproc` value to `2048` or greater
-* Set the `maxfiles` value to `10000`

--- a/docs/topics_5/plugin-install.adoc
+++ b/docs/topics_5/plugin-install.adoc
@@ -20,10 +20,9 @@ For more information about link:https://marketplace.visualstudio.com/items?itemN
 
 * If you are using Eclipse, and not Red Hat CodeReady Studio, you must install JBoss Tools before installing the {PluginNameTitle}.
 
-* {PluginName} on macOS has the following prerequisites:
+* {PluginName} on macOS has the following prerequisite:
 
 ** Set the `maxproc` value to `2048` or greater
-** Set the `maxfiles` value to `10000`
 
 .Installing the plugin
 

--- a/docs/topics_5/rn-known-issues.adoc
+++ b/docs/topics_5/rn-known-issues.adoc
@@ -22,11 +22,11 @@ At the time of release, the following known issues are identified as major issue
 
 |link:https://issues.redhat.com/browse/WINDUP-2704[WINDUP-2704]
 |Web UI & Windup-as-a-Service
-|On macOS, the `run_mta.sh` script sets the soft limit of open files to `100000`.
+|On macOS, the `run_mta.sh` script sets the soft limit of open files to `100000`. This issue was reported in MTA version 5.0.0 and resolved in 5.0.1.
 
 |link:https://issues.redhat.com/browse/WINDUP-2705[WINDUP-2705]
 |Web UI & Windup-as-a-Service
-|On macOS, the `mta-cli` script sets the soft limit of open files to `100000`.
+|On macOS, the `mta-cli` script sets the soft limit of open files to `100000`. This issue was reported in MTA version 5.0.0 and resolved in 5.0.1.
 
 |link:https://issues.redhat.com/browse/WINDUPRULE-607[WINDUPRULE-607]
 |OpenShift

--- a/docs/topics_5/templates/document-attributes.adoc
+++ b/docs/topics_5/templates/document-attributes.adoc
@@ -39,7 +39,7 @@
 :DocInfoProductNameURL: migration_toolkit_for_applications
 
 :OpenShiftProductNumber: 4.5
-:ProductVersion: 5.0.0
+:ProductVersion: 5.0.1
 
 :UserCLIBookName: CLI Guide
 :RulesDevBookName: Rules Development Guide

--- a/docs/topics_5/web-install-zip.adoc
+++ b/docs/topics_5/web-install-zip.adoc
@@ -12,16 +12,9 @@ The {WebName} has been tested with Chrome and Firefox.
 * OpenJDK 1.8, OpenJDK 11, Oracle JDK 1.8, or Oracle JDK 11
 * 16 GB RAM
 
-macOS has the following additional prerequisites:
+macOS has the following additional prerequisite:
 
 * Set the `maxproc` value to `2048` or greater.
-
-ifeval::["{ProductVersion}" == "5.0.0"]
-* Set the `maxfiles` value to `10000`.
-endif::[]
-ifeval::["{ProductVersion}" != "5.0.0"]
-* Set the `maxfiles` value to `100000`.
-endif::[]
 
 .Procedure
 


### PR DESCRIPTION
1. Description of ulimit items in Known Issues changed to indicate that they were resolved in version 5.0.1 (as per Phil's request).
2. {ProductVersion} changed to 5.0.1 -- only impact on document is to change the name of file downloaded for installation of the Eclipse plugin. Change confirmed by Phil.
3. Resolved https://issues.redhat.com/browse/MIGENG-829 by removing the limits to ulimit that were in the documentation.
4. Other references to maxfiles removed. 