### PR TITLE
Fix of product name: Open JDK -> OpenJDK

### DIFF
--- a/docs/topics_5/web-execution-config.adoc
+++ b/docs/topics_5/web-execution-config.adoc
@@ -21,7 +21,7 @@ The targets displayed under the Transformation Path heading are the most commonl
 
 * Linux (`linux`)
 
-* Open JDK (`openjdk`)
+* OpenJDK (`openjdk`)
 
 Other available targets can be selected using the _Advanced Options_ dialogue.
 


### PR DESCRIPTION
Only one occurrence in all version 5 files.  