### PR TITLE
Correcting typo in instructions for running mta script

### DIFF
--- a/docs/topics_5/installation.adoc
+++ b/docs/topics_5/installation.adoc
@@ -90,7 +90,7 @@ ifdef::web-console-guide[]
 * Linux operating system:
 +
 ----
-$ <MTA_HOME>/run_mta.sh
+$ <MTA_HOME> ./run_mta.sh
 ----
 
 * Windows operating system:

--- a/docs/topics_5/web-start.adoc
+++ b/docs/topics_5/web-start.adoc
@@ -7,7 +7,7 @@ Run the script to start the {WebName}.
 
 [source,options="nowrap",subs="+quotes"]
 ----
-$ <MTA_HOME>/run_mta.sh
+$ <MTA_HOME> ./run_mta.sh
 ----
 
 NOTE: In a Windows environment, use the `run_mta.bat` script.


### PR DESCRIPTION
Changed text from $ <MTA_HOME>/run_mta.sh> to $ <MTA_HOME> ./run_mta.sh