### PR TITLE
File duplication warning

### DIFF
--- a/docs/topics_5/installation.adoc
+++ b/docs/topics_5/installation.adoc
@@ -78,7 +78,9 @@ ifeval::["{context}" != "web-console-openshift"]
 +
 [NOTE]
 ====
-If you are installing on a Windows operating system, extract the `.zip` file to a folder named `mta` to avoid a `Path too long` error.
+If you are installing on a Windows operating system:
+. Extract the `.zip` file to a folder named `mta` to avoid a `Path too long` error.
+. If a *Confirm file replace* window is displayed during extraction, click *Yes to all*. 
 ====
 endif::[]
 +


### PR DESCRIPTION
Resolves https://issues.redhat.com/browse/WINDUP-2770.
Adds a note to the MTA web console installation instructions telling Windows users to choose "Yes" if they get a "Replace duplicate file" message during extraction of the .zip file.  