### PR TITLE
Access reports when MTA web console installed on OCP using template

### DIFF
--- a/docs/topics_5/installing-web-console-on-openshift.adoc
+++ b/docs/topics_5/installing-web-console-on-openshift.adoc
@@ -62,10 +62,21 @@ Two templates are provided, one for shared storage and one without shared storag
 . Click the *{ProductName}* template.
 . Click *Instantiate Template*.
 endif::[]
-ifdef::ocp-45,ocp-41[]
+ifdef::ocp-45[]
 . Review the application settings and click *Create*.
 . In the *Topology* view, wait for the pods to start.
 . Click the *Open URL* button of the `mta` Pod to open the {WebName} in a new browser window.
+endif::[]
+ifdef::ocp-41[]
+. Review the application settings and click *Create*.
+. In the *Topology* view, wait for the pods to start.
+. Click the *Open URL* button of the `mta` Pod to open the {WebName} in a new browser window.
++
+[NOTE]
+====
+The instructions above point your browser to an HTTP address that does not support viewing static reports.
+To point to an HTTPS address that supports viewing static reports, use the following URL: `\https://secure-mta-web-console-$<OpenShift address>`.
+====
 endif::[]
 ifdef::ocp-311[]
 . Switch to the *Service Catalog* perspective and click *Import YAML/JSON* in the upper-right corner of the web console.
@@ -81,6 +92,12 @@ Two templates are provided, one for shared storage and one without shared storag
 . Switch to the *Cluster Console*.
 . Click *Workloads* -> *Pods* and verify that the {ProductShortName} pods are running.
 . Click *Networking* -> *Routes* and then click the URL beside the `mta-web-console` application to open the {WebName} in a new browser window.
++
+[NOTE]
+====
+The instructions above point your browser to an HTTP address that does not support viewing static reports.
+To point to an HTTPS address that supports viewing static reports, use the following URL: `\https://secure-mta-web-console-$<OpenShift address>`.
+====
 endif::[]
 . Enter the user name `mta` and the password `password` and click *Log in*.
 

--- a/docs/topics_5/rn-known-issues.adoc
+++ b/docs/topics_5/rn-known-issues.adoc
@@ -14,10 +14,6 @@ At the time of release, the following known issues are identified as major issue
 |Component
 |Summary
 
-|link:https://issues.redhat.com/browse/WINDUP-2904[WINDUP-2904]
-|Web UI & Windup-as-a-Service
-|Analysis configuration settings are not updated in the wizard unless the *Next* button is clicked.
-
 |link:https://issues.redhat.com/browse/WINDUPRULE-607[WINDUPRULE-607]
 |OpenShift
 |RHAMT 4.3.1 installation on OpenShift Container Platform fails. The `WebConsole` and `Executor` pods are not running.
@@ -62,10 +58,6 @@ At the time of release, the following known issues are identified as major issue
 |link:https://issues.redhat.com/browse/WINDUP-2551[WINDUP-2551]
 |Technical Debt
 |RHAMT does not run on Zulu.
-
-|link:https://issues.redhat.com/browse/WINDUP-2549[WINDUP-2549]
-|Web UI & Windup-as-a-Service
-|When RHAMT 4.3.1 is deployed on OpenShift Container Platform, analysis results cannot be viewed.
 
 |link:https://issues.redhat.com/browse/WINDUP-2521[WINDUP-2521]
 |Web UI & Windup-as-a-Service

--- a/docs/topics_5/rn-resolved-issues.adoc
+++ b/docs/topics_5/rn-resolved-issues.adoc
@@ -13,6 +13,18 @@ For a full list of all issues resolved in this release, see the list of link:htt
 |ID
 |Summary
 
+|link:https://issues.redhat.com/browse/WINDUP-2941[WINDUP-2941]
+|MTA reports are slow to load, do not include Target Runtime labels on Application list, and do not have working feedback controls.
+
+|link:https://issues.redhat.com/browse/WINDUP-2333[WINDUP-2333]
+|The MTA web console installed on OpenShift by means of a template cannot access the reports using HTTPS.
+
+|link:https://issues.redhat.com/browse/WINDUP-2801[WINDUP-2801]
+|The MTA web console installed on OpenShift by means of the MTA Operator cannot access the reports using HTTPS.
+
+|link:https://issues.redhat.com/browse/WINDUP-2910[WINDUP-2910]
+|Problems analyizing applications built with JDK 11.
+
 |link:https://issues.redhat.com/browse/WINDUP-2759[WINDUP-2759]
 |Lucene index builder mistakenly identifies Spring packages as application packages.
 


### PR DESCRIPTION
Resolves https://issues.redhat.com/browse/WINDUP-2333
Preview: http://file.emea.redhat.com/rhoch/17012021/template_url/html-single/#installing-web-console-on-openshift_ocp-45