### PR TITLE
Fixing broken links in MTA docs

### DIFF
--- a/docs/getting-started-guide/master-docinfo.xml
+++ b/docs/getting-started-guide/master-docinfo.xml
@@ -1,4 +1,4 @@
-<title>{GettingStartedBookName}</title>
+<title>{IntroToMTABookName}</title>
 <productname>{DocInfoProductName}</productname>
 <productnumber>{DocInfoProductNumber}</productnumber>
 <subtitle>Learn how to use the {ProductName} to migrate and modernize Java applications and components.</subtitle>

--- a/docs/getting-started-guide/master.adoc
+++ b/docs/getting-started-guide/master.adoc
@@ -8,15 +8,15 @@ include::topics/templates/document-attributes.adoc[]
 :context: getting-started-guide
 :getting-started-guide:
 
-= {GettingStartedBookName}
+= {IntroToMTABookName}
 
 //Inclusive language statement
 include::topics/making-open-source-more-inclusive.adoc[]
 
 == Introduction
 
-// About the {GettingStartedBookName}
-include::topics/about-the-gs-guide.adoc[leveloffset=+2]
+// About the {IntroToMTABookName}
+include::topics/about-the-intro-to-mta-guide.adoc[leveloffset=+2]
 
 // About the Toolkit
 include::topics/what-is-the-toolkit.adoc[leveloffset=+1]

--- a/docs/topics/about-rules.adoc
+++ b/docs/topics/about-rules.adoc
@@ -1,5 +1,6 @@
 // Module included in the following assemblies:
 // * docs/rules-development-guide/master.adoc
+// * docs/getting-started-guide/master.adoc
 
 [id='about-rules_{context}']
 = About {ProductShortName} rules
@@ -19,5 +20,5 @@ otherwise(action)
 {ProductShortName} provides a comprehensive set of standard migration rules out-of-the-box. Because applications may contain custom libraries or components, {ProductShortName} allows you to write your own rules to identify use of components or software that may not be covered by the existing ruleset.
 
 ifndef::rules-development-guide[]
-If you plan to write your own custom rules, see the {ProductDocRulesGuideURL} in _{RulesDevBookName}_ for detailed instructions.
+If you plan to write your own custom rules, see the {ProductDocRulesGuideURL}[_{RulesDevBookName}_] for detailed instructions.
 endif::rules-development-guide[]

--- a/docs/topics/about-the-intro-to-mta-guide.adoc
+++ b/docs/topics/about-the-intro-to-mta-guide.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 // * docs/getting-started-guide/master.adoc
 
-[id='about-the-gs-guide_{context}']
-= About the {GettingStartedBookName}
+[id='about-the-intro-to-mta-guide_{context}']
+= About the {IntroToMTABookName}
 
 This guide is for engineers, consultants, and others who want to use the {ProductName} ({ProductShortName}) to migrate Java applications or other components. It provides an overview of the {ProductName} and how to get started using the tools to plan and execute your migration.

--- a/docs/topics/cli-args.adoc
+++ b/docs/topics/cli-args.adoc
@@ -145,7 +145,7 @@ The `--source` argument now provides version support, which follows the link:htt
 ====
 When migrating to JBoss EAP, be sure to specify the version, for example, `eap:6`. Specifying only `eap` will run rulesets for all versions of JBoss EAP, including those not relevant to your migration path.
 
-See link:{ProductDocGettingStartedGuideURL}/index#migration_paths_getting-started-guide[Supported migration paths] in the {ProductShortName} _{GettingStartedBookName}_ for which JBoss EAP version is appropriate for your source platform.
+See link:{ProductDocIntroToMTAGuideURL}/index#migration_paths_getting-started-guide[Supported migration paths] in the {ProductShortName} _{IntroToMTABookName}_ for the appropriate JBoss EAP version.
 ====
 
 [id='target_argument_{context}']
@@ -166,7 +166,7 @@ The `--target` argument now provides version support, which follows the link:htt
 ====
 When migrating to JBoss EAP, be sure to specify the version in the target, for example, `eap:6`. Specifying only `eap` will run rulesets for all versions of JBoss EAP, including those not relevant to your migration path.
 
-See link:{ProductDocGettingStartedGuideURL}/index#migration_paths_getting-started-guide[Supported migration paths] in the {ProductShortName} _{GettingStartedBookName}_ for which JBoss EAP version is appropriate for your source platform.
+See link:{ProductDocIntroToMTAGuideURL}/index#migration_paths_getting-started-guide[Supported migration paths] in the {ProductShortName} _{IntroToMTABookName}_ for the appropriate JBoss EAP version.
 ====
 
 [id='packages_argument_{context}']

--- a/docs/topics/installing-web-console-on-openshift.adoc
+++ b/docs/topics/installing-web-console-on-openshift.adoc
@@ -41,7 +41,7 @@ endif::[]
 ifdef::ocp-41,ocp-311[]
 .Procedure
 
-. Download the installation archive file from the link:https://developers.redhat.com/products/mta/download[{ProductShortName} download page].
+. Navigate to the link:{MTADownloadPageURL}[{ProductShortName} Download page] and download the {WebName} `Local install & OpenShift` file.
 . Extract the `.zip` file to a directory, for example, `MTA_HOME`.
 endif::[]
 ifdef::ocp-45[]

--- a/docs/topics/installing-web-console.adoc
+++ b/docs/topics/installing-web-console.adoc
@@ -53,7 +53,7 @@ ifdef::cli-guide,maven-guide,web-console-guide,plugin-guide,plugin-guide-offline
 * macOS: The value of `maxproc` must be `2048` or greater.
 endif::[]
 ifdef::plugin-guide,plugin-guide-offline[]
-* link:https://developers.redhat.com/products/codeready-studio/download/[Red Hat CodeReady Studio]
+* link:{CodeReadyStudioDownloadPageURL}[Red Hat CodeReady Studio]
 +
 _or_
 
@@ -62,8 +62,15 @@ endif::[]
 
 .Procedure
 
+ifdef::cli-guide[]
+. Navigate to the link:{MTADownloadPageURL}[{ProductShortName} Download page] and download the `Migration Toolkit CLI` file.
+endif::[]
+
+ifdef::web-console-guide[]
+. Navigate to the link:{MTADownloadPageURL}[{ProductShortName} Download page] and download the {WebName} `Local install & OpenShift` file.
+endif::[]
+
 ifdef::cli-guide,web-console-guide[]
-. Download the installation archive file from the link:https://developers.redhat.com/products/mta/download[{ProductShortName} Download page].
 . Extract the `.zip` file to a directory of your choice.
 +
 [NOTE]
@@ -120,7 +127,7 @@ $ mvn clean install
 The `windup-maven-plugin` jar is installed in your local Maven repository.
 endif::[]
 ifdef::plugin-guide-offline[]
-. Download the link:{ProductDownloadURL}{IDEPluginFilename}-{ProductVersion}.zip[IDE Plugin archive file].
+. Navigate to the link:{MTADownloadPageURL}[Migration Toolkit for Applications download site] and download the `IDE Plugin Repository` file.
 endif::[]
 ifdef::plugin-guide,plugin-guide-offline[]
 . Launch your IDE.

--- a/docs/topics/maven-arguments.adoc
+++ b/docs/topics/maven-arguments.adoc
@@ -134,7 +134,8 @@ The `targetTechnologies` argument now provides version support, which follows th
 ====
 When migrating to JBoss EAP, be sure to specify the version in the target, for example, `eap:6`. Specifying only `eap` will run rulesets for all versions of JBoss EAP, including those not relevant to your migration path.
 
-See link:{ProductDocGettingStartedGuideURL}#migration_paths[Supported migration paths] in the {ProductShortName} _{GettingStartedBookName}_ for which JBoss EAP version is appropriate for your source platform.
+See link:{ProductDocIntroToMTAGuideURL}/index#migration_paths_getting-started-guide[Supported migration paths] in the {ProductShortName} _{IntroToMTABookName}_ for the appropriate JBoss EAP version.
+
 ====
 
 [id='packages_argument_{context}']

--- a/docs/topics/rules-guide-intro.adoc
+++ b/docs/topics/rules-guide-intro.adoc
@@ -5,6 +5,6 @@
 
 This guide is for engineers, consultants, and others who want to create custom XML-based rules for {ProductName} ({ProductShortName}) tools.
 
-If you are new to {ProductShortName}, it is recommended that you start with the link:{ProductDocUserGuideURL}[_{GettingStartedBookName}_] for an overview of the {ProductName} features and system requirements. It is also recommended that you review the link:{ProductDocUserGuideURL}[_{UserCLIBookName}_], which provides detailed instructions on how to install and execute the {CLIName}.
+For more information, see the link:{ProductDocIntroToMTAGuideURL}[_{IntroToMTABookName}_] for an overview and the link:{ProductDocUserGuideURL}[_{UserCLIBookName}_] for details.
 
-If you would like to contribute to the {ProductShortName} source code base or provide Java-based rule add-ons, see the link:{ProductDocCoreGuideURL}[_{CoreDevelopmentBookName}_].
+To contribute to the {ProductShortName} source code base or provide Java-based rule add-ons, see the link:{ProductDocCoreGuideURL}[_{CoreDevelopmentBookName}_].

--- a/docs/topics/templates/document-attributes.adoc
+++ b/docs/topics/templates/document-attributes.adoc
@@ -44,7 +44,7 @@
 :UserCLIBookName: CLI Guide
 :RulesDevBookName: Rules Development Guide
 :PluginBookName: IDE Plugin Guide
-:GettingStartedBookName: Introduction to the Migration Toolkit for Applications
+:IntroToMTABookName: Introduction to the Migration Toolkit for Applications
 :WebConsoleBookName: Web Console Guide
 :MavenBookName: Maven Plugin Guide
 :ReleaseNotesName: Release Notes
@@ -72,7 +72,8 @@
 :ProductDocUserGuideURL: https://access.redhat.com/documentation/en-us/{DocInfoProductNameURL}/{DocInfoProductNumber}/html-single/cli_guide
 :ProductDocRulesGuideURL: https://access.redhat.com/documentation/en-us/{DocInfoProductNameURL}/{DocInfoProductNumber}/html-single/rules_development_guide
 :ProductDocPluginGuideURL: https://access.redhat.com/documentation/en-us/{DocInfoProductNameURL}/{DocInfoProductNumber}/html-single/ide_plugin_guide
-:ProductDocGettingStartedGuideURL: https://access.redhat.com/documentation/en-us/{DocInfoProductNameURL}/{DocInfoProductNumber}/html-single/introduction_to_the_migration_toolkit_for_applications
+:ProductDocIntroToMTAGuideURL: https://access.redhat.com/documentation/en-us/{DocInfoProductNameURL}/{DocInfoProductNumber}/html-single/introduction_to_the_migration_toolkit_for_applications
+
 :ProductDocWebConsoleGuideURL: https://access.redhat.com/documentation/en-us/{DocInfoProductNameURL}/{DocInfoProductNumber}/html-single/web_console_guide
 :ProductDocMavenGuideURL: https://access.redhat.com/documentation/en-us/{DocInfoProductNameURL}/{DocInfoProductNumber}/html-single/maven_plugin_guide
 :OpenShiftDocsURL: https://docs.openshift.com/container-platform/{OpenShiftProductNumber}
@@ -82,8 +83,9 @@
 // Point to the GitHub wiki version since there is no product version of this guide.
 :ProductDocCoreGuideURL: https://github.com/windup/windup/wiki/Core-Development-Guide
 
-// URL for downloads on developers.redhat.com
-:ProductDownloadURL: https://developers.redhat.com/products/
+// URLs for downloads on developers.redhat.com
+:MTADownloadPageURL: https://developers.redhat.com/products/mta/download
+:CodeReadyStudioDownloadPageURL: https://developers.redhat.com/products/codeready-studio/download/
 
 // KBase Article links:
 :KBArticleTechnologyPreview: https://access.redhat.com/support/offerings/techpreview

--- a/docs/topics/what-is-the-toolkit.adoc
+++ b/docs/topics/what-is-the-toolkit.adoc
@@ -22,5 +22,5 @@ ifndef::getting-started-guide[]
 [discrete]
 == How do I learn more?
 
-See the link:{ProductDocGettingStartedGuideURL}[_{GettingStartedBookName}_] to learn more about the features, supported configurations, system requirements, and available tools in the {ProductName}.
+See the link:{ProductDocIntroToMTAGuideURL}[_{IntroToMTABookName}_] to learn more about the features, supported configurations, system requirements, and available tools in the {ProductName}.
 endif::getting-started-guide[]


### PR DESCRIPTION
Fixes the broken links in MTA docs issue raised in https://issues.redhat.com/browse/WINDUP-3014. 

Previews:

For the repaired link to _Introduction to the Migration Tools for Applications_ guide, formerly the _Getting Started Guide_:
http://file.emea.redhat.com/rhoch/01032021/clig/html-single/#about_mta_cli-guide
http://file.emea.redhat.com/rhoch/01032021/maveng/html-single/#about_mta_maven-guide
http://file.emea.redhat.com/rhoch/01032021/pluging/html-single/#about_mta_plugin-guide
http://file.emea.redhat.com/rhoch/01032021/rulesg/html-single/#about_rules_dev_guide_rules-development-guide
http://file.emea.redhat.com/rhoch/01032021/webcg/html-single/#about_mta_web-console-guide

For the repaired link to the IDE plugin download:
http://file.emea.redhat.com/rhoch/01032021/pluging/html-single/#installing-web-console_plugin-guide-offline

Installation procedures for the web console, CLI, and IDE plugin:

http://file.emea.redhat.com/rhoch/01032021/webcg/html-single/#installing_the_web_console
http://file.emea.redhat.com/rhoch/01032021/pluging/html-single/#installing-web-console_plugin-guide
http://file.emea.redhat.com/rhoch/01032021/clig/html-single/#installing-web-console_cli-guide



_Intoduction to the Migration Toolkit for Applications_  http://file.emea.redhat.com/rhoch/01032021/gsg/html-single/
