### PR TITLE
Only J2E version of eclipse tar works with MTA plugin

### DIFF
--- a/docs/topics/installing-web-console.adoc
+++ b/docs/topics/installing-web-console.adoc
@@ -57,7 +57,8 @@ ifdef::plugin-guide,plugin-guide-offline[]
 +
 _or_
 
-* link:http://www.eclipse.org/downloads/[Eclipse] with JBoss Tools. To install JBoss Tools on Eclipse, navigate to link:https://www.eclipse.org/[Eclipse.org], click *More* -> *Documentation*, and select *Eclipse Marketplace User Guide*.
+* link:https://www.eclipse.org/downloads/packages/release/2020-09/r[Eclipse 2020-09 R] installed.
+* JBoss Tools installed. To install JBoss Tools on Eclipse, navigate to link:https://www.eclipse.org/[Eclipse.org], click *More* -> *Documentation*, and select *Eclipse Marketplace User Guide*.
 endif::[]
 
 .Procedure


### PR DESCRIPTION
Resolves: https://issues.redhat.com/browse/WINDUP-3049
Gives the user the correct link for the Eclipse .tar file to download.