### PR TITLE
Correct Eclipse download

### DIFF
--- a/docs/topics/installing-web-console.adoc
+++ b/docs/topics/installing-web-console.adoc
@@ -57,7 +57,8 @@ ifdef::plugin-guide,plugin-guide-offline[]
 +
 _or_
 
-* link:https://www.eclipse.org/downloads/packages/release/2020-09/r[Eclipse 2020-09 R] installed.
+* link:https://www.eclipse.org/downloads/packages/release/2020-09/r/eclipse-ide-enterprise-java-developers[Eclipse IDE for Java Enterprise Developers 2020-09 R] installed.
+
 * JBoss Tools installed. To install JBoss Tools on Eclipse, navigate to link:https://www.eclipse.org/[Eclipse.org], click *More* -> *Documentation*, and select *Eclipse Marketplace User Guide*.
 endif::[]
 


### PR DESCRIPTION
For MTA 5.1.3. 

Resolves: https://issues.redhat.com/browse/WINDUP-3049?focusedCommentId=16030031&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-16030031

Corrects the file the user should download to use Eclipse with MTA 5.1.x 

Previews: Sections 2 and 3 (prerequisites): https://deploy-preview-415--windup-documentation.netlify.app/docs/plugin-guide/master/index.html#installing-web-console_plugin-guide