### PR TITLE
Fix Jira links in MTA repo

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -2,7 +2,7 @@
 
 Improvements to Windup documentation are welcome.
 
-In order to contribute, you will need a GitHub account and to have `git` installed on your machine. You can also log a link:https://issues.jboss.org/projects/WINDUP/issues[Jira issue] to track the changes.
+In order to contribute, you will need a GitHub account and to have `git` installed on your machine. You can also log a link:https://issues.redhat.com/projects/WINDUP[Jira issue] to track the changes.
 
 Use the following steps to submit a change to the Windup documentation repository.
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ See the [Contributors Guide](CONTRIBUTING.adoc) for details.
 
 ## Reporting a documentation bug
 
-To report a Windup documentation issue, submit a [Jira issue](https://issues.jboss.org/projects/WINDUP/issues) with the *Component* field set to *Documentation*.
+To report a Windup documentation issue, submit a [Jira issue](https://issues.redhat.com/projects/WINDUP) with the *Component* field set to *Documentation*.
 
 ## Repository Structure
 

--- a/docs/topics/important-links.adoc
+++ b/docs/topics/important-links.adoc
@@ -7,7 +7,7 @@
 
 * {ProductShortName} forums: https://developer.jboss.org/en/windup
 * {ProductShortName} JIRA issue trackers
-** Core {ProductShortName}: https://issues.jboss.org/browse/WINDUP
-** {ProductShortName} Rules: https://issues.jboss.org/browse/WINDUPRULE
+** Core {ProductShortName}: https://issues.redhat.com/projects/WINDUP
+** {ProductShortName} Rules: https://issues.redhat.com/projects/WINDUPRULE
 * {ProductShortName} mailing list: jboss-migration-feedback@redhat.com
 * {ProductShortName} IRC channel: Server FreeNode (`irc.freenode.net`), channel `#windup` (http://transcripts.jboss.org/channel/irc.freenode.org/%23windup/index.html[transcripts]).

--- a/docs/topics/proc_reporting-issues.adoc
+++ b/docs/topics/proc_reporting-issues.adoc
@@ -15,7 +15,7 @@ You must sign up for a Jira account in order to create an issue.
 
 .Procedure
 
-. Open a browser and navigate to the Jira link:https://issues.jboss.org/secure/CreateIssue!default.jspa[Create Issue] page.
+. Open a browser and navigate to the Jira link:https://issues.redhat.com/projects/WINDUP[Create Issue] page.
 . Click *Log In* on the upper right of the page and enter your credentials.
 . Select the following options and click *Next*.
 

--- a/docs/topics/report-issues.adoc
+++ b/docs/topics/report-issues.adoc
@@ -10,7 +10,7 @@ NOTE: If you do not have a JIRA user account, you must create an account in orde
 
 == Creating a JIRA issue
 
-. Open a browser and navigate to the JIRA link:https://issues.jboss.org/secure/CreateIssue!default.jspa[Create issue] page.
+. Open a browser and navigate to the JIRA link:https://issues.redhat.com/projects/WINDUP[Create issue] page.
 +
 If you have not yet logged in, click the *Log In* link at the top right side of the page and enter your credentials.
 

--- a/docs/topics/rules-important-links.adoc
+++ b/docs/topics/rules-important-links.adoc
@@ -6,7 +6,7 @@
 * {ProductShortName} Javadoc: http://windup.github.io/windup/docs/latest/javadoc
 * {ProductShortName} forums: https://developer.jboss.org/en/windup
 * {ProductShortName} JIRA issue trackers
-** Core {ProductShortName}: https://issues.jboss.org/browse/WINDUP
-** {ProductShortName} Rules: https://issues.jboss.org/browse/WINDUPRULE
+** Core {ProductShortName}: https://issues.redhat.com/projects/WINDUP
+** {ProductShortName} Rules: https://issues.redhat.com/projects/WINDUPRULE
 * {ProductShortName} mailing list: jboss-migration-feedback@redhat.com
 * {ProductShortName} IRC channel: Server FreeNode (`irc.freenode.net`), channel `#windup` (http://transcripts.jboss.org/channel/irc.freenode.org/%23windup/index.html[transcripts])

--- a/docs/topics/web-openshift-troubleshoot.adoc
+++ b/docs/topics/web-openshift-troubleshoot.adoc
@@ -11,7 +11,7 @@ The {ProductName} uses Jira as its issue tracking system. If you encounter any i
 
 NOTE: If you do not already have a Jira account, you must sign up for one in order to create a Jira issue.
 
-. Open a browser and navigate to the Jira link:https://issues.jboss.org/secure/CreateIssue!default.jspa[Create Issue] page.
+. Open a browser and navigate to the Jira link:https://issues.redhat.com/projects/WINDUP[Create Issue] page.
 +
 If you have not yet logged in, click *Log In* on the upper right of the page and enter your credentials.
 


### PR DESCRIPTION
Fixes broken links in MTA repo that point Jira boards for WINDUP and WINDUPRULES

(No Jira)

Previews: 
https://deploy-preview-420--windup-documentation.netlify.app/docs/web-console-guide/master/index.html#troubleshooting-a-web-console-installation-on-openshift ("Reporting issues")  
Note -- it's possible a user reading this section might want to report an issue with OpenShift, not MTA, so I suggest leaving the title as is rather than change it to "Reporting issues with MTA" as in the two documents that follow.

https://deploy-preview-420--windup-documentation.netlify.app/docs/cli-guide/master/index.html#report_issues_cli-guide (A.4.3 "Reporting issues with MTA")

https://deploy-preview-420--windup-documentation.netlify.app/docs/maven-guide/master/index.html#report_issues_maven-guide (A.4.3 "Reporting issues with MTA")

https://deploy-preview-420--windup-documentation.netlify.app/docs/rules-development-guide/master/index.html#rules_important_links_rules-development-guide (A.2.2 "Resources")

https://deploy-preview-420--windup-documentation.netlify.app/docs/getting-started-guide/master/index.html#important_links_getting-started-guide  (A.1.2 "Resources")

