### PR TITLE
MTA 5.1.4 release notes: Thorntail -> JBoss EAP XP 2

### DIFF
--- a/docs/topics/rn-new-features.adoc
+++ b/docs/topics/rn-new-features.adoc
@@ -64,3 +64,9 @@ The current release contains rules for migrating to the latest version of Quarku
 These rules ensure that the applications are migrated to a target that has the latest features, resolved issues, and patches.
 
 These rules will be updated for future Quarkus releases.
+
+.Rules for migrating from Thorntail to JBoss EAP XP 2
+
+The current release contains rules for migrating from Thorntail to JBoss EAP XP 2. The target of these rules is `eapxp:2`.
+
+For more information about this migration path, see the link:https://access.redhat.com/documentation/en-us/red_hat_jboss_enterprise_application_platform/7.3/html/red_hat_jboss_eap_xp_2.0.0_migration_guide/thorntail-application-maven-project-migration_default#migrating-a-thorntail-application-maven-project-into-eap-xp_default[Red Hat JBoss EAP XP 2.0.0 Migration Guide].


### PR DESCRIPTION
MTA 5.1.4 (to be released 13 May 2021)
Resolves latest addition to https://issues.redhat.com/browse/WINDUP-3045.
Preview: "Rules for migrating from Thorntail to JBoss EAP XP 2" in https://deploy-preview-424--windup-documentation.netlify.app/docs/release-notes/release_notes-5.1/master/index.html#rn-new-features_release-notes 