### PR TITLE
Fixed xref to Rules Development Guide

### DIFF
--- a/docs/cli-guide/master.adoc
+++ b/docs/cli-guide/master.adoc
@@ -60,6 +60,8 @@ include::topics/tech-tags.adoc[leveloffset=+2]
 // Rule Story Points
 include::topics/about-story-points.adoc[leveloffset=+2]
 
+For more information on categorizing tasks, see link:{ProductDocRulesGuideURL}/rule_categories_rules-development-guide#rule_categories_rules-development-guide[Using custom rule categories].
+
 === Additional Resources
 
 // Get Involved

--- a/docs/maven-guide/master.adoc
+++ b/docs/maven-guide/master.adoc
@@ -53,6 +53,8 @@ include::topics/maven-logging-properties.adoc[leveloffset=+2]
 // Rule Story Points
 include::topics/about-story-points.adoc[leveloffset=+2]
 
+For more information on categorizing tasks, see link:{ProductDocRulesGuideURL}/rule_categories_rules-development-guide#rule_categories_rules-development-guide[Using custom rule categories].
+
 === Additional resources
 
 // Get Involved

--- a/docs/rules-development-guide/master.adoc
+++ b/docs/rules-development-guide/master.adoc
@@ -85,7 +85,7 @@ include::topics/rule-categories.adoc[leveloffset=+1]
 // Rule Story Points
 include::topics/about-story-points.adoc[leveloffset=+2]
 
-For more information on categorizing tasks, see xref:rule_categories_rules-development-guide[Using Custom Rule Categories].
+For more information on categorizing tasks, see xref:rule-categories_{context}[Using custom rule categories].
 
 === Additional resources
 

--- a/docs/topics/about-story-points.adoc
+++ b/docs/topics/about-story-points.adoc
@@ -59,7 +59,3 @@ Optional:: If the migration task is not completed, the application should work, 
 Potential:: The task should be examined during the migration process, but there is not enough detailed information to determine if the task is mandatory for the migration to succeed. An example of this would be migrating a third-party proprietary type where there is no directly compatible type.
 
 Information:: The task is included to inform you of the existence of certain files. These may need to be examined or modified as part of the modernization effort, but changes are typically not required. An example of this would be the presence of a logging dependency or a Maven `pom.xml`.
-
-ifndef::rules-development-guide[]
-For more information on categorizing tasks, see link:{ProductDocRulesGuideURL}#rule_categories_rules-development-guide[Using Custom Rule Categories] in the _{RulesDevBookName}_.
-endif::rules-development-guide[]

--- a/docs/topics/overriding-rules.adoc
+++ b/docs/topics/overriding-rules.adoc
@@ -7,7 +7,7 @@
 
 You can override core rules distributed with {ProductShortName} or even custom rules. For example, you can change the matching conditions, effort, or hint text for a rule. This is done by making a copy of the original rule, marking it as a rule override, and making the necessary adjustments.
 
-You can disable a rule by creating a rule override with an empty `<rule` element.
+You can disable a rule by creating a rule override with an empty `<rule>` element.
 
 == Overriding a rule
 

--- a/docs/topics/rule-categories.adoc
+++ b/docs/topics/rule-categories.adoc
@@ -3,7 +3,7 @@
 // * docs/rules-development-guide/master.adoc
 
 [id='rule-categories_{context}']
-= Using Custom rule categories
+= Using custom rule categories
 
 You can create custom rule categories and assign {ProductShortName} rules to them.
 


### PR DESCRIPTION
MTA 5.1.3 (current release)
Fixed a bad xref and corrected two minor typos. 