### PR TITLE
MTA Maven Plugin Guide: corrected installation procedures

### DIFF
--- a/docs/maven-guide/master.adoc
+++ b/docs/maven-guide/master.adoc
@@ -26,9 +26,6 @@ include::topics/about-maven.adoc[leveloffset=+2]
 
 == Getting started
 
-// Installing the {MavenNameTitle}
-include::topics/installing-plugin.adoc[leveloffset=+2]
-
 // Run the {MavenNameTitle}
 include::topics/maven-run.adoc[leveloffset=+2]
 

--- a/docs/topics/installing-plugin.adoc
+++ b/docs/topics/installing-plugin.adoc
@@ -1,14 +1,7 @@
 // Module included in the following assemblies:
 //
-// * docs/maven-guide/master.adoc
 // * docs/plugin-guide/master.adoc
 
-ifdef::maven-guide[]
-[id="installing-plugin_{context}"]
-= Installing the {MavenNameTitle}
-
-You can install the {MavenName} in your local Maven repository.
-endif::[]
 ifdef::plugin-guide[]
 [id="installing-ide-plugin-connected-environment_{context}"]
 = Installing the {PluginName} in a connected environment
@@ -29,11 +22,6 @@ endif::[]
 
 .Prerequisites
 
-ifdef::maven-guide[]
-* OpenJDK 1.8, OpenJDK 11, Oracle JDK 1.8, _or_ Oracle JDK 11
-* 8 GB RAM
-* Maven 3.2.5 or later
-endif::[]
 ifdef::plugin-guide,disconnected[]
 * link:{CodeReadyStudioDownloadPageURL}[Red Hat CodeReady Studio] _or_ link:https://www.eclipse.org/downloads/packages/release/2020-09/r/eclipse-ide-enterprise-java-developers[Eclipse IDE for Java Enterprise Developers 2020-09 R]
 * JBoss Tools
@@ -44,27 +32,6 @@ endif::[]
 
 .Procedure
 
-ifdef::maven-guide[]
-. Clone the {MavenName} Github repository:
-+
-----
-$ git clone https://github.com/windup/windup-maven-plugin.git
-----
-
-. Navigate to the `windup-maven-plugin` directory.
-+
-----
-$ cd windup-maven-plugin
-----
-
-. Build the project:
-+
-----
-$ mvn clean install
-----
-+
-The `windup-maven-plugin` jar is installed in your local Maven repository.
-endif::[]
 ifdef::disconnected[]
 . Navigate to the link:{MTADownloadPageURL}[Migration Toolkit for Applications download site] and download the `IDE Plugin Repository` file.
 endif::[]

--- a/docs/topics/maven-run.adoc
+++ b/docs/topics/maven-run.adoc
@@ -7,6 +7,13 @@
 
 The {MavenName} is executed by including a reference to the plugin inside your application's `pom.xml` file. When the application is built, the {MavenName} is executed and generates the reports for analysis.
 
+.Prerequisites
+
+* OpenJDK 1.8, OpenJDK 11, Oracle JDK 1.8, _or_ Oracle JDK 11
+* 8 GB RAM
+* Maven 3.2.5 or later
+* If you are installing on macOS, the value of `maxproc` must be `2048` or greater.
+
 .Procedure
 
 . Add the following `<plugin>` to your application's `pom.xml` file:

--- a/docs/topics/templates/document-attributes.adoc
+++ b/docs/topics/templates/document-attributes.adoc
@@ -61,7 +61,7 @@
 // :ProductVersion: 4.0
 :ProductDistributionVersion: 5.1.Final
 :ProductDistribution: mta-cli-{ProductDistributionVersion}
-:MavenProductVersion: 5.1.Final
+:MavenProductVersion: 5.1.4.Final
 
 // ********
 // * URLs *


### PR DESCRIPTION
MTA version 5.1.4
Resolves: https://issues.redhat.com/browse/WINDUP-3097 -- removes redundant section and changes the Maven product version in the parent project’s pom.xml file.
Preview: https://deploy-preview-427--windup-documentation.netlify.app/docs/maven-guide/master/index.html#getting-started

Note: in making this change, I needed to modify the installation file used for IDE Plugin Guide. I verified that the guide builds properly and that its content was unchanged by the changes made here.