### PR TITLE
Remove all references to installing MTA on OCP 3.11

### DIFF
--- a/docs/topics/installing-web-console-on-openshift.adoc
+++ b/docs/topics/installing-web-console-on-openshift.adoc
@@ -18,15 +18,10 @@ ifdef::ocp-41[]
 
 You can install the {WebName} on {ocp-short} 4.2-4.5 by importing a template and instantiating it to create the {WebName} application.
 endif::[]
-ifdef::ocp-311[]
-= Installing the {WebName} on {ocp-short} 3.11
-
-You can install the {WebName} on {ocp-short} 3.11 by importing a template into the OpenShift Service Catalog.
-endif::[]
 
 .Prerequisites
 
-ifdef::ocp-45,ocp-41,ocp-311[]
+ifdef::ocp-45,ocp-41[]
 * 4 vCPUs, 8 GB RAM, and 40 GB persistent storage.
 * One or more projects in which you can install the {WebName}.
 endif::[]
@@ -38,7 +33,7 @@ ifdef::ocp-45[]
 * `project-admin-user` privileges to install the {WebName} application in a project.
 endif::[]
 
-ifdef::ocp-41,ocp-311[]
+ifdef::ocp-41[]
 .Procedure
 
 . Navigate to the link:{MTADownloadPageURL}[{ProductShortName} Download page] and download the {WebName} `Local install & OpenShift` file.
@@ -80,23 +75,6 @@ ifdef::ocp-45,ocp-41[]
 . Review the application settings and click *Create*.
 . In the *Topology* view, click the `mta-web-console` application and then click the *Resources* tab.
 . Click the `secure-mta-web-console` route to open the {WebName} in a new browser window.
-endif::[]
-ifdef::ocp-311[]
-. Launch the OpenShift web console.
-. Switch to the *Service Catalog* perspective and click *Import YAML/JSON* in the upper-right corner of the web console.
-+
-image::openshift-console.png[OpenShift console]
-. Select *mta* from the *Add to Project* list.
-. Click *Browse* and select a template from the `MTA_HOME/openshift/templates/` directory.
-+
-Two templates are provided, one for shared storage and one without shared storage.
-
-. Click *Create*.
-. Click *Continue*.
-. Review the application settings and click *Create*.
-. Switch to the *Cluster Console*.
-. Click *Workloads* -> *Pods* and verify that the {ProductShortName} pods are running.
-. Click *Networking* -> *Routes* and then click the `secure-mta-web-console` route to open the {WebName} in a new browser window.
 endif::[]
 . Enter the user name `mta` and the password `password` and click *Log in*.
 

--- a/docs/web-console-guide/master.adoc
+++ b/docs/web-console-guide/master.adoc
@@ -35,7 +35,7 @@ include::topics/installing-web-console-or-cli-tool.adoc[leveloffset=+2]
 
 You can install the {WebName} on {ocp-short} 4.6 and later versions with the {ProductName} Operator.
 
-You can install the {WebName} on {ocp-short} 4.2-4.5 and 3.11 by importing a template and instantiating it to create the {WebName} application.
+You can install the {WebName} on {ocp-short} 4.2-4.5 by importing a template and instantiating it to create the {WebName} application.
 
 :web-console-guide!:
 :context: ocp-45
@@ -46,10 +46,6 @@ include::topics/installing-web-console-on-openshift.adoc[leveloffset=+3]
 :ocp-41:
 include::topics/installing-web-console-on-openshift.adoc[leveloffset=+3]
 :ocp-41!:
-:context: ocp-311
-:ocp-311:
-include::topics/installing-web-console-on-openshift.adoc[leveloffset=+3]
-:ocp-311!:
 :web-console-guide:
 ==== Troubleshooting a {WebName} installation on OpenShift
 


### PR DESCRIPTION
MTA 1.5.4

Resolves: https://issues.redhat.com/browse/WINDUP-3113.  OCP 3.11 will no longer be supported from 1st July.

Note that there are no other references to OCP 3.11 in the rest of the MTA repo. 

Preview of installation chapter: https://deploy-preview-437--windup-documentation.netlify.app/docs/web-console-guide/master/index.html#installing-the-web-console

I have checked this "manually" to ensure that all remaining installation prerequisites and procedures were not affected. 