### PR TITLE
MTA 5.2: Update Eclipse and CRS versions

### DIFF
--- a/docs/topics/eclipse-installing-plugin.adoc
+++ b/docs/topics/eclipse-installing-plugin.adoc
@@ -15,11 +15,11 @@ ifdef::disconnected[]
 You can install the {PluginName} in a disconnected network environment.
 endif::[]
 
-The {PluginName} has been tested with the Eclipse IDE for Java Enterprise Developers 2020-09 R and Red Hat CodeReady Studio 12.15.
+The {PluginName} has been tested with the Eclipse IDE for Java Enterprise Developers 2021-03 and Red Hat CodeReady Studio 12.19.1.
 
 .Prerequisites
 
-* link:{CodeReadyStudioDownloadPageURL}[Red Hat CodeReady Studio] _or_ link:https://www.eclipse.org/downloads/packages/release/2020-09/r/eclipse-ide-enterprise-java-developers[Eclipse IDE for Java Enterprise Developers 2020-09 R]
+* link:{CodeReadyStudioDownloadPageURL}[Red Hat CodeReady Studio] _or_ link:https://www.eclipse.org/downloads/packages/release/2021-03/r/eclipse-ide-java-developers[Eclipse IDE for Java Enterprise Developers 2021-03]. If you are installing Eclipse, be sure to download Eclipse IDE for Java Enterprise Developers 2021-03, not 2021-06.
 * JBoss Tools, installed with the link:https://www.eclipse.org/mpc/[Eclipse Marketplace Client].
 * If you are installing the {PluginName} on macOS, the value of `maxproc` must be `2048` or greater.
 


### PR DESCRIPTION
MTA 5.2

Resolves: https://issues.redhat.com/browse/WINDUP-3135

Preview: https://deploy-preview-449--windup-documentation.netlify.app/docs/eclipse-code-ready-studio-guide/master/index.html#installing-plugin_eclipse-code-ready-studio-guide