### PR TITLE
Headline style applied to title of VS Code extension guide

### DIFF
--- a/docs/vs-code-extension-guide/master.adoc
+++ b/docs/vs-code-extension-guide/master.adoc
@@ -8,7 +8,7 @@ include::topics/templates/document-attributes.adoc[]
 :context: vsc-extension-guide
 :vsc-extension-guide-guide:
 
-= Visual Studio Code extension guide
+= Visual Studio Code Extension Guide
 
 //Inclusive language statement
 include::topics/making-open-source-more-inclusive.adoc[]


### PR DESCRIPTION
MTA 5.2
Applies headline style to the title of the VS Code extension guide