### PR TITLE
Small changes to Eclipse/CodeReady Studio and VS Code guides

### DIFF
--- a/docs/topics/about-vscode-extension.adoc
+++ b/docs/topics/about-vscode-extension.adoc
@@ -15,10 +15,3 @@ The {ProductShortName} extension analyzes your projects using customizable rules
 ifdef::getting-started-guide[]
 For more information about using the {ProductShortName} extension, see the {ProductShortName} link:{ProductDocVscGuideURL}[_Visual Studio Code Extension Guide_].
 endif::[]
-
-[IMPORTANT]
-====
-The {ProductName} ({ProductShortName}) extension for Visual Studio Code is provided as a Technology Preview only. Technology Preview features provide early access to upcoming product innovations, enabling you to test functionality and provide feedback during the development process. However, these features are not fully supported under Red Hat Subscription Level Agreements, may not be functionally complete, and are not intended for production use.
-
-See link:{KBArticleTechnologyPreview}[Technology Preview Features Support Scope] on the Red&nbsp;Hat Customer Portal.
-====

--- a/docs/topics/eclipse-installing-plugin.adoc
+++ b/docs/topics/eclipse-installing-plugin.adoc
@@ -21,7 +21,13 @@ The {PluginName} has been tested with the Eclipse IDE for Java Enterprise Develo
 
 * link:{CodeReadyStudioDownloadPageURL}[Red Hat CodeReady Studio] _or_ link:https://www.eclipse.org/downloads/packages/release/2021-03/r/eclipse-ide-java-developers[Eclipse IDE for Java Enterprise Developers 2021-03]. If you are installing Eclipse, be sure to download Eclipse IDE for Java Enterprise Developers 2021-03, not 2021-06.
 * JBoss Tools, installed with the link:https://www.eclipse.org/mpc/[Eclipse Marketplace Client].
-* OpenJDK 1.8, OpenJDK 11, Oracle JDK 1.8, _or_ Oracle JDK 11
+* One of the following Java Development Kits (JDKs):
+
+** OpenJDK 1.8
+** OpenJDK 11
+** Oracle JDK 1.8
+** Oracle JDK 11
+
 * If you are installing the {PluginName} on macOS, the value of `maxproc` must be `2048` or greater.
 
 .Procedure

--- a/docs/topics/eclipse-installing-plugin.adoc
+++ b/docs/topics/eclipse-installing-plugin.adoc
@@ -21,6 +21,7 @@ The {PluginName} has been tested with the Eclipse IDE for Java Enterprise Develo
 
 * link:{CodeReadyStudioDownloadPageURL}[Red Hat CodeReady Studio] _or_ link:https://www.eclipse.org/downloads/packages/release/2021-03/r/eclipse-ide-java-developers[Eclipse IDE for Java Enterprise Developers 2021-03]. If you are installing Eclipse, be sure to download Eclipse IDE for Java Enterprise Developers 2021-03, not 2021-06.
 * JBoss Tools, installed with the link:https://www.eclipse.org/mpc/[Eclipse Marketplace Client].
+* OpenJDK 1.8, OpenJDK 11, Oracle JDK 1.8, _or_ Oracle JDK 11
 * If you are installing the {PluginName} on macOS, the value of `maxproc` must be `2048` or greater.
 
 .Procedure

--- a/docs/topics/eclipse-reviewing-issues.adoc
+++ b/docs/topics/eclipse-reviewing-issues.adoc
@@ -24,7 +24,7 @@ The following icons indicate the severity and state of an issue:
 |Icon |Description
 |image::error.png[Mandatory] |The issue must be fixed for a successful migration.
 |image::info.gif[Optional] |The issue is optional to fix for migration.
-|image::warning.png[Warning] |The issue might be an issue during migration.
+|image::warning.png[Warning] |The issue might need to be addressed during migration.
 |image::fixedIssue.gif[Resolved] |The issue was resolved.
 |image::stale_issue.gif[Stale] |The issue is stale. The code marked as an issue was modified since the last time that {ProductShortName} identified it as an issue.
 |image::quickfix_error.png[Mandatory with quick fix] |A quick fix is available for this issue, which is mandatory to fix for a successful migration.

--- a/docs/topics/installing-vs-code-extension.adoc
+++ b/docs/topics/installing-vs-code-extension.adoc
@@ -10,7 +10,12 @@ You can install the {ProductShortName} extension for Visual Studio Code (VS Code
 .Prerequisites
 
 * 8 GB RAM
-* OpenJDK 1.8, OpenJDK 11, Oracle JDK 1.8, _or_ Oracle JDK 11
+* One of the following Java Development Kits (JDKs):
+
+** OpenJDK 1.8
+** OpenJDK 11
+** Oracle JDK 1.8
+** Oracle JDK 11
 
 .Procedure
 

--- a/docs/topics/installing-vs-code-extension.adoc
+++ b/docs/topics/installing-vs-code-extension.adoc
@@ -10,7 +10,7 @@ You can install the {ProductShortName} extension for Visual Studio Code (VS Code
 .Prerequisites
 
 * 8 GB RAM
-* JDK 11 or later
+* JDK 8 or JDK 11
 
 .Procedure
 

--- a/docs/topics/installing-vs-code-extension.adoc
+++ b/docs/topics/installing-vs-code-extension.adoc
@@ -10,7 +10,7 @@ You can install the {ProductShortName} extension for Visual Studio Code (VS Code
 .Prerequisites
 
 * 8 GB RAM
-* JDK 8 or JDK 11
+* OpenJDK 1.8, OpenJDK 11, Oracle JDK 1.8, _or_ Oracle JDK 11
 
 .Procedure
 

--- a/docs/topics/installing-web-console-or-cli-tool.adoc
+++ b/docs/topics/installing-web-console-or-cli-tool.adoc
@@ -21,7 +21,13 @@ endif::[]
 
 .Prerequisites
 
-* OpenJDK 1.8, OpenJDK 11, Oracle JDK 1.8, _or_ Oracle JDK 11
+* One of the following Java Development Kits (JDKs):
+
+** OpenJDK 1.8
+** OpenJDK 11
+** Oracle JDK 1.8
+** Oracle JDK 11
+
 * 8 GB RAM
 * If you are installing on macOS, the value of `maxproc` must be `2048` or greater.
 

--- a/docs/topics/maven-run.adoc
+++ b/docs/topics/maven-run.adoc
@@ -9,7 +9,13 @@ The {MavenName} is executed by including a reference to the plugin inside your a
 
 .Prerequisites
 
-* OpenJDK 1.8, OpenJDK 11, Oracle JDK 1.8, _or_ Oracle JDK 11
+* One of the following Java Development Kits (JDKs):
+
+** OpenJDK 1.8
+** OpenJDK 11
+** Oracle JDK 1.8
+** Oracle JDK 11
+
 * 8 GB RAM
 * Maven 3.2.5 or later
 * If you are installing on macOS, the value of `maxproc` must be `2048` or greater.

--- a/docs/topics/plugin-icon-legend.adoc
+++ b/docs/topics/plugin-icon-legend.adoc
@@ -13,7 +13,7 @@
 |Icon |Description
 |image::error.png[Mandatory] |The issue must be fixed for a successful migration.
 |image::info.gif[Optional] |The issue is optional to fix for migration.
-|image::warning.png[Warning] |The issue  might need to be addressed during migration.
+|image::warning.png[Warning] |The issue might need to be addressed during migration.
 |image::fixedIssue.gif[Resolved] |The issue was resolved.
 |image::stale_issue.gif[Stale] |The issue is stale. The code marked as an issue was modified since the last time that {ProductShortName} identified it as an issue.
 |image::quickfix_error.png[Mandatory with quick fix] |A quick fix is available for this issue, which is mandatory to fix for a successful migration.

--- a/docs/topics/plugin-icon-legend.adoc
+++ b/docs/topics/plugin-icon-legend.adoc
@@ -13,7 +13,7 @@
 |Icon |Description
 |image::error.png[Mandatory] |The issue must be fixed for a successful migration.
 |image::info.gif[Optional] |The issue is optional to fix for migration.
-|image::warning.png[Warning] |The issue might be an issue during migration.
+|image::warning.png[Warning] |The issue  might need to be addressed during migration.
 |image::fixedIssue.gif[Resolved] |The issue was resolved.
 |image::stale_issue.gif[Stale] |The issue is stale. The code marked as an issue was modified since the last time that {ProductShortName} identified it as an issue.
 |image::quickfix_error.png[Mandatory with quick fix] |A quick fix is available for this issue, which is mandatory to fix for a successful migration.

--- a/docs/topics/system-requirements.adoc
+++ b/docs/topics/system-requirements.adoc
@@ -5,7 +5,13 @@
 [id="system-requirements_{context}"]
 = System requirements
 
-* OpenJDK 1.8, OpenJDK 11, Oracle JDK 1.8, _or_ Oracle JDK 11
+* One of the following Java Development Kits (JDKs):
+
+** OpenJDK 1.8
+** OpenJDK 11
+** Oracle JDK 1.8
+** Oracle JDK 11
+
 * 8 GB RAM
 * If you are installing on macOS, the value of `maxproc` must be `2048` or greater.
 

--- a/docs/topics/vs-code-extension-reviewing-issues.adoc
+++ b/docs/topics/vs-code-extension-reviewing-issues.adoc
@@ -16,5 +16,5 @@ You can use the {ProductShortName} extension icons to prioritize issues based on
 . Prioritize issues based on the following icons, which are displayed next to each hint:
 
 ** image:vs_mandatory.png[Mandatory] : The issue must be fixed for a successful migration.
-** image:vs_potential.png[Warning] : The issue might be an issue during migration.
+** image:vs_potential.png[Warning] : The issue  might need to be addressed during migration.
 ** image:vs_optional.png[Optional or Quick Fix] : The issue is optional to fix for migration. This icon is also used to indicate any Quick Fixes available for an issue.

--- a/docs/topics/vs-code-extension-reviewing-issues.adoc
+++ b/docs/topics/vs-code-extension-reviewing-issues.adoc
@@ -16,5 +16,5 @@ You can use the {ProductShortName} extension icons to prioritize issues based on
 . Prioritize issues based on the following icons, which are displayed next to each hint:
 
 ** image:vs_mandatory.png[Mandatory] : The issue must be fixed for a successful migration.
-** image:vs_potential.png[Warning] : The issue  might need to be addressed during migration.
+** image:vs_potential.png[Warning] : The issue might need to be addressed during migration.
 ** image:vs_optional.png[Optional or Quick Fix] : The issue is optional to fix for migration. This icon is also used to indicate any Quick Fixes available for an issue.

--- a/docs/topics/what-is-the-toolkit.adoc
+++ b/docs/topics/what-is-the-toolkit.adoc
@@ -21,7 +21,7 @@ The {ProductName} ({ProductShortName}) is an extensible and customizable rule-ba
 * Migrating from Oracle WebLogic or IBM WebSphere Application Server to Red Hat JBoss Enterprise Application Platform
 * Containerizing applications and making them cloud-ready
 * Migrating from Java Spring Boot to Quarkus
-* Updating from Oracle Open JDK to OpenJDK
+* Updating from Oracle JDK to OpenJDK
 
 For more information about use cases and migration paths, see the link:https://developers.redhat.com/products/mta/use-cases[MTA for developers] web page.
 

--- a/docs/topics/what-is-the-toolkit.adoc
+++ b/docs/topics/what-is-the-toolkit.adoc
@@ -17,10 +17,11 @@ The {ProductName} ({ProductShortName}) is an extensible and customizable rule-ba
 
 {ProductShortName} examines application artifacts, including project source directories and application archives, and then produces an HTML report highlighting areas needing changes. {ProductShortName} supports many migration paths including the following examples:
 
-* Migrating from enterprise application servers to Red Hat JBoss Enterprise Application Platform
+* Upgrading to the latest release of Red Hat JBoss Enterprise Application Platform
+* Migrating from Oracle WebLogic or IBM WebSphere Application Server to Red Hat JBoss Enterprise Application Platform
 * Containerizing applications and making them cloud-ready
-* Migrating from Spring Boot to Quarkus
-* Updating OpenJDK versions
+* Migrating from Java Spring Boot to Quarkus
+* Updating from Oracle Open JDK to OpenJDK
 
 For more information about use cases and migration paths, see the link:https://developers.redhat.com/products/mta/use-cases[MTA for developers] web page.
 


### PR DESCRIPTION
Resolves second set of requests in https://issues.redhat.com/browse/WINDUP-3167

Previews:
1. "Technology preview" note removed from description of VS Code extension: https://deploy-preview-456--windup-documentation.netlify.app/docs/vs-code-extension-guide/master/index.html#about-vscode-extension_vsc-extension-guide
2. Changes to bulleted list in "What is the Migration Toolkit  for Applications": https://deploy-preview-456--windup-documentation.netlify.app/docs/vs-code-extension-guide/master/index.html#what-is-the-toolkit_vsc-extension-guide
3. Prerequisites for Eclipse/CodeReady Studio plugin (same for both connected and disconnected environments): https://deploy-preview-456--windup-documentation.netlify.app/docs/eclipse-code-ready-studio-guide/master/index.html#eclipse-installing-plugin-connected-environment_eclipse-code-ready-studio-guide
4. Prerequisites for VS Code extension: https://deploy-preview-456--windup-documentation.netlify.app/docs/vs-code-extension-guide/master/index.html#installing-vs-code-extension_vsc-extension-guide
5. Prerequisites for web console: https://github.com/windup/windup-documentation/pull/456#issue-1021946077
6. Prerequisites for Maven plugin: https://deploy-preview-456--windup-documentation.netlify.app/docs/maven-guide/master/index.html#maven-run_maven-guide
7.  Change of wording in VS Code extension guide, Section 4.1. step 5: https://deploy-preview-456--windup-documentation.netlify.app/docs/vs-code-extension-guide/master/index.html#vs-code-extension-reviewing-issues_vsc-extension-guide
8. Change in parallel section of Eclipse/CodeReady Studio Plugin guide: 
https://deploy-preview-456--windup-documentation.netlify.app/docs/eclipse-code-ready-studio-guide/master/index.html#eclipse-reviewing-issues_eclipse-code-ready-studio-guide
