### PR TITLE
Draft: Replacing attributes with actual titles

### DIFF
--- a/docs/cli-guide/master-docinfo.xml
+++ b/docs/cli-guide/master-docinfo.xml
@@ -1,4 +1,4 @@
-<title>{UserCLIBookName}</title>
+<title>CLI Guide</title>
 <productname>{DocInfoProductName}</productname>
 <productnumber>{DocInfoProductNumber}</productnumber>
 <subtitle>Learn how to use the {ProductName} to migrate your applications.</subtitle>

--- a/docs/cli-guide/master.adoc
+++ b/docs/cli-guide/master.adoc
@@ -1,6 +1,6 @@
 include::topics/templates/document-attributes.adoc[]
 [id="cli-guide"]
-= {UserCLIBookName}
+= CLI Guide
 
 :toc:
 :toclevels: 4

--- a/docs/eclipse-code-ready-studio-guide/master-docinfo.xml
+++ b/docs/eclipse-code-ready-studio-guide/master-docinfo.xml
@@ -1,4 +1,4 @@
-<title>Eclipse and Red Hat CodeReady Studio Guide/title>
+<title>Eclipse and Red Hat CodeReady Studio Guide/<title>
 <productname>{DocInfoProductName}</productname>
 <productnumber>{DocInfoProductNumber}</productnumber>
 <subtitle>Identify and resolve migration issues by analyzing your applications with the MTA plugin for Eclipse or Red Hat CodeReady Studio.</subtitle>

--- a/docs/eclipse-code-ready-studio-guide/master-docinfo.xml
+++ b/docs/eclipse-code-ready-studio-guide/master-docinfo.xml
@@ -1,4 +1,4 @@
-<title>{EclipseCrsGuideTitle}</title>
+<title>Eclipse and Red Hat CodeReady Studio Guide/title>
 <productname>{DocInfoProductName}</productname>
 <productnumber>{DocInfoProductNumber}</productnumber>
 <subtitle>Identify and resolve migration issues by analyzing your applications with the MTA plugin for Eclipse or Red Hat CodeReady Studio.</subtitle>

--- a/docs/eclipse-code-ready-studio-guide/master.adoc
+++ b/docs/eclipse-code-ready-studio-guide/master.adoc
@@ -1,6 +1,6 @@
 include::topics/templates/document-attributes.adoc[]
 [id="eclipse-code-ready-studio-guide"]
-= {EclipseGuideTitle}
+= Eclipse and Red Hat CodeReady Studio Guide
 
 :toc:
 :context: eclipse-code-ready-studio-guide

--- a/docs/getting-started-guide/master-docinfo.xml
+++ b/docs/getting-started-guide/master-docinfo.xml
@@ -1,4 +1,4 @@
-<title>{IntroToMTABookName}</title>
+<title>Introduction to the Migration Toolkit for Applications</title>
 <productname>{DocInfoProductName}</productname>
 <productnumber>{DocInfoProductNumber}</productnumber>
 <subtitle>Learn how to use the {ProductName} to migrate and modernize Java applications and components.</subtitle>

--- a/docs/getting-started-guide/master.adoc
+++ b/docs/getting-started-guide/master.adoc
@@ -8,7 +8,7 @@ include::topics/templates/document-attributes.adoc[]
 :context: getting-started-guide
 :getting-started-guide:
 
-= {IntroToMTABookName}
+= Introduction to the Migration Toolkit for Applications
 
 //Inclusive language statement
 include::topics/making-open-source-more-inclusive.adoc[]

--- a/docs/maven-guide/master-docinfo.xml
+++ b/docs/maven-guide/master-docinfo.xml
@@ -1,4 +1,4 @@
-<title>{UserMavenBookName}</title>
+<title>Maven Plugin Guide</title>
 <productname>{DocInfoProductName}</productname>
 <productnumber>{DocInfoProductNumber}</productnumber>
 <subtitle>Integrate the {ProductName} into the Maven build process.</subtitle>

--- a/docs/maven-guide/master.adoc
+++ b/docs/maven-guide/master.adoc
@@ -8,7 +8,7 @@ include::topics/templates/document-attributes.adoc[]
 :context: maven-guide
 :maven-guide:
 
-= {MavenBookName}
+= Maven Plugin Guide
 
 //Inclusive language statement
 include::topics/making-open-source-more-inclusive.adoc[]

--- a/docs/release-notes/master-docinfo.xml
+++ b/docs/release-notes/master-docinfo.xml
@@ -1,4 +1,4 @@
-<title>{ReleaseNotesName}</title>
+<title>Release Notes</title>
 <productname>{DocInfoProductName}</productname>
 <productnumber>{DocInfoProductNumber}</productnumber>
 <subtitle>New features, known issues, and resolved issues</subtitle>

--- a/docs/release-notes/master.adoc
+++ b/docs/release-notes/master.adoc
@@ -6,7 +6,7 @@ include::topics/templates/document-attributes.adoc[]
 :context: release-notes
 :release-notes:
 
-= {ReleaseNotesName}
+= Release Notes
 
 //Inclusive language statement
 include::topics/making-open-source-more-inclusive.adoc[]

--- a/docs/rules-development-guide/master-docinfo.xml
+++ b/docs/rules-development-guide/master-docinfo.xml
@@ -1,4 +1,4 @@
-<title>{RulesDevBookName}</title>
+<title>Rules Development Guide</title>
 <productname>{DocInfoProductName}</productname>
 <productnumber>{DocInfoProductNumber}</productnumber>
 <subtitle>Create custom rules to enhance migration coverage.</subtitle>

--- a/docs/rules-development-guide/master.adoc
+++ b/docs/rules-development-guide/master.adoc
@@ -8,7 +8,7 @@ include::topics/templates/document-attributes.adoc[]
 :context: rules-development-guide
 :rules-development-guide:
 
-= {RulesDevBookName}
+= Rules Development Guide
 
 //Inclusive language statement
 include::topics/making-open-source-more-inclusive.adoc[]

--- a/docs/topics/templates/document-attributes.adoc
+++ b/docs/topics/templates/document-attributes.adoc
@@ -23,7 +23,6 @@
 :WebNameTitle: Web Console
 
 :PluginName: MTA plugin
-:EclipseGuideTitle: Eclipse and CodeReady Studio Plugin Guide
 
 :IDEPluginFilename: migrationtoolkit-mta-eclipse-plugin-repository
 
@@ -46,7 +45,6 @@
 :IntroToMTABookName: Introduction to the Migration Toolkit for Applications
 :WebConsoleBookName: Web Console Guide
 :MavenBookName: Maven Plugin Guide
-:ReleaseNotesName: Release Notes
 
 
 // This book is on GitHub wiki only

--- a/docs/web-console-guide/master-docinfo.xml
+++ b/docs/web-console-guide/master-docinfo.xml
@@ -1,4 +1,4 @@
-<title>{ProductWebName} Guide</title>
+<title>Web Console Guide</title>
 <productname>{DocInfoProductName}</productname>
 <productnumber>{DocInfoProductNumber}</productnumber>
 <subtitle>Use the Migration Toolkit for Applications web console to group your applications into projects for analysis.</subtitle>

--- a/docs/web-console-guide/master.adoc
+++ b/docs/web-console-guide/master.adoc
@@ -8,7 +8,7 @@ include::topics/templates/document-attributes.adoc[]
 :context: web-console-guide
 :web-console-guide:
 
-= {WebConsoleBookName}
+= Web Console Guide
 
 //Inclusive language statement
 include::topics/making-open-source-more-inclusive.adoc[]


### PR DESCRIPTION
MTA 5.2.x
No Jira.
Replaces document title attributes with actual titles throughout the MTA repo in master.adoc and master-docinfo.xml files. Removes attributes that are used only in these files. 