### PR TITLE
Revised MTA 5.2.1. Release notes and modified Eclipse/CodeReady Studio instructions

### DIFF
--- a/docs/eclipse-code-ready-studio-guide/master-docinfo.xml
+++ b/docs/eclipse-code-ready-studio-guide/master-docinfo.xml
@@ -1,4 +1,4 @@
-<title>Eclipse and Red Hat CodeReady Studio Guide/<title>
+<title>Eclipse and Red Hat CodeReady Studio Guide</title>
 <productname>{DocInfoProductName}</productname>
 <productnumber>{DocInfoProductNumber}</productnumber>
 <subtitle>Identify and resolve migration issues by analyzing your applications with the MTA plugin for Eclipse or Red Hat CodeReady Studio.</subtitle>

--- a/docs/topics/about-the-intro-to-mta-guide.adoc
+++ b/docs/topics/about-the-intro-to-mta-guide.adoc
@@ -5,4 +5,4 @@
 [id="about-the-intro-to-mta-guide_{context}"]
 = About the {IntroToMTABookName}
 
-This guide is for engineers, consultants, and others who want to use the {ProductName} ({ProductShortName}) to migrate Java applications or other components. It provides an overview of the {ProductName} and how to get started using the tools to plan and execute your migration.
+This guide is for engineers, consultants, and others who want to use the {ProductName} ({ProductShortName}) to migrate Java applications or other components. It provides an overview of the {ProductName} and how to get started using the tools to plan and run your migration.

--- a/docs/topics/create-first-xml-rule.adoc
+++ b/docs/topics/create-first-xml-rule.adoc
@@ -206,7 +206,7 @@ $ cp /home/<USER_NAME>/migration-rules/rules/JBoss5-web-class-loading.windup.xml
 [discrete]
 == Testing the rule
 
-Open a terminal and execute the following command, passing the test file as an input argument and a directory for the output report.
+Open a terminal and run the following command, passing the test file as an input argument and a directory for the output report.
 
 [options="nowrap",subs="+quotes"]
 ----
@@ -227,7 +227,7 @@ Report created: /home/<USER_NAME>/migration-rules/reports/index.html
 Review the report to be sure that it provides the expected results. For a more detailed walkthrough of {ProductShortName} reports, see the link:{ProductDocUserGuideURL}#review_reports[Review the reports] section of the {ProductShortName} _{UserCLIBookName}_.
 
 . Open `/home/<USER_NAME>/migration-rules/reports/index.html` in a web browser.
-. Verify that the rule executed.
+. Verify that the rule ran successfully.
 .. From the main landing page, click the *Rule providers execution overview* link to open the Rule Providers Execution Overview.
 +
 .. Find the `JBoss5-web-class-loading_001` rule and verify that its *Status?* is `Condition met` and its *Result?* is `success`.

--- a/docs/topics/eclipse-installing-plugin.adoc
+++ b/docs/topics/eclipse-installing-plugin.adoc
@@ -15,15 +15,18 @@ ifdef::disconnected[]
 You can install the {PluginName} in a disconnected network environment.
 endif::[]
 
-The {PluginName} has been tested with the Eclipse IDE for Java Enterprise Developers 2021-03 and Red Hat CodeReady Studio 12.19.1.
+The {PluginName} has been tested with the Eclipse IDE for Java Enterprise Developers 2021-09 and Red Hat CodeReady Studio 12.21.0.GA.
 
 [discrete]
 include::jdk-hardware-mac-prerequisites.adoc[leveloffset=+2]
 
-* link:{CodeReadyStudioDownloadPageURL}[Red Hat CodeReady Studio] _or_ link:https://www.eclipse.org/downloads/packages/release/2021-03/r/eclipse-ide-java-developers[Eclipse IDE for Java Enterprise Developers 2021-03]. If you are installing Eclipse, be sure to download Eclipse IDE for Java Enterprise Developers 2021-03, not 2021-06.
-* JBoss Tools, installed with the link:https://www.eclipse.org/mpc/[Eclipse Marketplace Client].
+* link:{CodeReadyStudioDownloadPageURL}[Red Hat CodeReady Studio] _or_ link:https://www.eclipse.org/downloads/packages/release/2021-09/r/eclipse-ide-java-developers[Eclipse IDE for Java Enterprise Developers 2021-09]
+* JBoss Tools, installed with the link:https://www.eclipse.org/mpc/[Eclipse Marketplace Client]
+* link:http://download.eclipse.org/mylyn/releases/latest[Mylyn SDK and frameworks], installed with Eclipse
 
-
+ifdef::disconnected[]
+* Connected workstation for all downloads
+endif::[]
 
 .Procedure
 
@@ -44,4 +47,4 @@ endif::[]
 . Select all the *JBoss Tools - MTA* check boxes and click *Next*.
 . Review the installation details and click *Next*.
 . Accept the terms of the license agreement and click *Finish*.
-. Restart  Eclipse or CodeReady Studio.
+. Restart Eclipse or CodeReady Studio.

--- a/docs/topics/maven-access-reports.adoc
+++ b/docs/topics/maven-access-reports.adoc
@@ -5,7 +5,7 @@
 [id="maven-access-reports_{context}"]
 = Accessing the report
 
-When you execute {ProductName}, the report is generated in the `OUTPUT_REPORT_DIRECTORY` that you specify using the `outputDirectory` argument in the `pom.xml`. Upon completion of the build, you will see the following message in the build log.
+When you run {ProductName}, the report is generated in the `OUTPUT_REPORT_DIRECTORY` that you specify using the `outputDirectory` argument in the `pom.xml`. Upon completion of the build, you will see the following message in the build log.
 
 [options="nowrap",subs="+quotes"]
 ----

--- a/docs/topics/maven-multi-module.adoc
+++ b/docs/topics/maven-multi-module.adoc
@@ -7,7 +7,7 @@
 
 To use the {MavenName} in a project with multiple modules, place the configuration inside the parent's `pom.xml`. During execution the {MavenName} will generate a single report that contains the analysis for the parent and any child modules.
 
-NOTE: It is strongly recommended to set `inherited` to false in multi-module projects; otherwise, the {MavenName} will be executed when each child is compiled, resulting in multiple executions of the {MavenName} against the child modules. Setting `inherited` to false results in each project being analyzed a single time and drastically decreased run times.
+NOTE: It is strongly recommended to set `inherited` to false in multi-module projects; otherwise, the {MavenName} will run when each child is compiled, resulting in multiple executions of the {MavenName} against the child modules. Setting `inherited` to false results in each project being analyzed a single time and drastically decreased run times.
 
 To run the {MavenName} in a project with multiple modules perform the following steps.
 
@@ -45,7 +45,7 @@ This `pom.xml` file differs from the default in the following attributes:
 +
 The above example demonstrates a set of recommended arguments.
 
-. Build the parent project. During the build process the {MavenName} will execute against all children in the project without further configuration.
+. Build the parent project. During the build process the {MavenName} runs against all children in the project without further configuration.
 +
 [source,options="nowrap"]
 ----

--- a/docs/topics/maven-run.adoc
+++ b/docs/topics/maven-run.adoc
@@ -5,7 +5,7 @@
 [id="maven-run_{context}"]
 = Running the {MavenNameTitle}
 
-The {MavenName} is executed by including a reference to the plugin inside your application's `pom.xml` file. When the application is built, the {MavenName} is executed and generates the reports for analysis.
+The {MavenName} is run by including a reference to the plugin inside your application's `pom.xml` file. When the application is built, the {MavenName} is run and generates the reports for analysis.
 
 [discrete]
 include::jdk-hardware-mac-prerequisites.adoc[leveloffset=+2]

--- a/docs/topics/method-deploy.adoc
+++ b/docs/topics/method-deploy.adoc
@@ -8,8 +8,8 @@
 .Red Hat migration methodology: Deploy phase
 image::RHAMT_AMM_Methodology_446947_0617_ECE_Deploy.png[Red Hat migration methodology: Deploy]
 
-The _Deploy_ phase is when you execute the plan created in the Design phase. In this phase, you scale the overall transformation process to complete the plan and bring all applications to their new production environment.
+The _Deploy_ phase is when you run the plan created in the Design phase. In this phase, you scale the overall transformation process to complete the plan and bring all applications to their new production environment.
 
-The plan is executed in iterations to deliver value incrementally. With each iteration, you continuously validate against the plan and document findings to improve the next sprint.
+The plan is run in iterations to deliver value incrementally. With each iteration, you continuously validate against the plan and document findings to improve the next sprint.
 
 The use of the {ProductName} {PluginName} increases speed in each iteration. It can be used with Eclipse or Red Hat CodeReady Studio, and marks migration issues directly in the source code, provides inline hints, and offers code change suggestions. See the link:{EclipseCrsGuideURL}[_{EclipseCrsGuideTitle}_] for information on how to use the {PluginName}.

--- a/docs/topics/optimize-performance.adoc
+++ b/docs/topics/optimize-performance.adoc
@@ -13,7 +13,7 @@ In general, {ProductShortName} spends about 40% of the time decompiling classes,
 
 Try these suggestions first before upgrading hardware.
 
-* If possible, execute {ProductShortName} against the source code instead of the archives. This eliminates the need to decompile additional JARs and archives.
+* If possible, run {ProductShortName} against the source code instead of the archives. This eliminates the need to decompile additional JARs and archives.
 * Specify a comma-separated list of the packages to be evaluated by {ProductShortName} using the `--packages` argument on the `<MTA_HOME>/bin/mta-cli` command line. If you omit this argument, {ProductShortName} will decompile everything, which has a big impact on performance.
 * Specify the `--excludeTags` argument where possible to exclude them from processing.
 * Avoid decompiling and analyzing any unnecessary packages and files, such as proprietary packages or included dependencies.

--- a/docs/topics/overriding-rules.adoc
+++ b/docs/topics/overriding-rules.adoc
@@ -23,7 +23,7 @@ Custom rules can be placed in `<MTA_HOME>/rules`, `${user.home}/.mta/rules/`, or
 +
 [NOTE]
 ====
-Rules from the original ruleset that are not overridden by the new ruleset are executed as normal.
+Rules from the original ruleset that are not overridden by the new ruleset are run as normal.
 ====
 
 . Ensure that you keep the same rule and ruleset IDs. When you copy the original rule XML, this ensures that the IDs match.

--- a/docs/topics/plugin-components.adoc
+++ b/docs/topics/plugin-components.adoc
@@ -11,7 +11,7 @@ Issue Explorer:: This view allows you to explore the {ProductShortName} issues f
 +
 If this view is not visible in the {ProductShortName} perspective, you can open it by selecting *Window* -> *Show View* -> *Issue Explorer*.
 
-{ProductShortName} Server:: The {ProductShortName} server is a separate process that executes the {ProductShortName} analysis, flags the migration issues, and generates the reports.
+{ProductShortName} Server:: The {ProductShortName} server is a separate process that runs the {ProductShortName} analysis, flags the migration issues, and generates the reports.
 +
 You can start, stop, and view the status of the {ProductShortName} server from *Issue Explorer*.
 

--- a/docs/topics/review-reports.adoc
+++ b/docs/topics/review-reports.adoc
@@ -292,7 +292,7 @@ This allows you to view the detailed reports for all archives that are shared ac
 
 Access this report from the report landing page by clicking the *Rule providers execution overview* link.
 
-This report provides the list of rules that executed when running the {ProductShortName} migration command against the application.
+This report provides the list of rules that ran when running the {ProductShortName} migration command against the application.
 
 .Rule providers execution overview
 image::report-jee-example-ruleprovider.png[Rule Provider Execution Overview]

--- a/docs/topics/rn-known-issues.adoc
+++ b/docs/topics/rn-known-issues.adoc
@@ -31,4 +31,8 @@ For a complete list of all known issues, see the list of link:https://issues.red
 |link:https://issues.redhat.com/browse/WINDUP-3005[WINDUP-3005]
 |Web console
 |The *Save* and *Save and run* buttons are not displayed on the *Custom rules* and *Custom labels* tabs on the *Analysis configuration* page.
+
+|link:https://issues.redhat.com/browse/WINDUP-3159[WINDUP-3159]
+|Web console
+|If you delete an application from a project after running an analysis, the number of applications is not updated when you rerun the analysis.
 |====

--- a/docs/topics/rn-new-features.adoc
+++ b/docs/topics/rn-new-features.adoc
@@ -7,25 +7,21 @@
 
 This section describes the new features of the {ProductName} ({ProductShortName}) {ProductVersion}.
 
-.Rules for migrating from Java EE8 to Jakarta EE9
-{ProductShortName} rules replace Java EE8 artifact dependencies and package import statements and rename XML schema namespaces, prefixed properties, and bootstrapping files for Jakarta EE9.
-
-Most rules contain quick fixes to automate source code changes when using an {ProductShortName} IDE plugin or extension for Eclipse, Eclipse Che, IntelliJ IDEA, Microsoft Visual Studio Code, or Red Hat CodeReady Studio.
-
-To execute the rules, use the target `jakarta-ee`.
-
-.OpenRewrite recipe support
-
-link:https://docs.openrewrite.org/[OpenRewrite] automates large-scale, distributed source code refactoring. You can execute OpenRewrite recipes by using the link:{ProductDocUserGuideURL}[{ProductShortName} CLI].
-
-The OpenRewrite recipe `org.jboss.windup.JavaxToJakarta`, which is shipped with {ProductShortName} 5.2.1, renames imported `javax` packages to their `jakarta` equivalents.
-
 [IMPORTANT]
 ====
-OpenRewrite recipe support is provided as Technology Preview only. Technology Preview features are not supported with Red Hat production service level agreements (SLAs), might not be functionally complete, and Red Hat does not recommend to use them for production. These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process.
+Rules for migrating from Java EE8 to Jakarta EE9 and OpenRewrite support are both provided as Technology Preview only. Technology Preview features are not supported with Red Hat production service level agreements (SLAs), might not be functionally complete, and Red Hat does not recommend to use them for production. These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process.
 
 See link:{KBArticleTechnologyPreview}[Technology Preview features support scope] on the Red&nbsp;Hat Customer Portal for information about the support scope for Technology Preview features.
 ====
+
+.Rules for migrating from Java EE8 to Jakarta EE9
+{ProductShortName} rules replace Java EE8 artifact dependencies and package import statements and rename XML schema namespaces, prefixed properties, and bootstrapping files for Jakarta EE9. You run these rules by specifying the `jakarta-ee` target.
+
+.OpenRewrite recipe support
+
+link:https://docs.openrewrite.org/[OpenRewrite] automates large-scale, distributed source code refactoring. You can run OpenRewrite recipes by using the link:{ProductDocUserGuideURL}[{ProductShortName} CLI].
+
+The recipe `org.jboss.windup.JavaxToJakarta` renames imported `javax` packages to their `jakarta` equivalents.
 
 .MTA extension for Visual Studio Code compatible with Codespaces
 

--- a/docs/topics/rn-resolved-issues.adoc
+++ b/docs/topics/rn-resolved-issues.adoc
@@ -16,6 +16,10 @@ At the time of the release, the following resolved issues have been identified a
 |Component
 |Summary
 
+|link:https://issues.redhat.com/browse/WINDUP-3201[WINDUP-3201]
+|Red Hat CodeReady Studio extension
+|The plugin cannot be used in Red Hat CodeReady Studio 12.21.0.GA.
+
 |link:https://issues.redhat.com/browse/WINDUP-3125[WINDUP-3125]
 |ItelliJ IDEA plugin and Visual Studio Code extension
 |The *Apply QuickFix* menu option is not disabled after a QuickFix is applied.

--- a/docs/topics/validation-report.adoc
+++ b/docs/topics/validation-report.adoc
@@ -9,7 +9,7 @@ Validation reports provide details about test rules and failures and contain the
 
 * *Summary*
 +
-This section contains the total number of tests executed and reports the number of errors and failures. It displays the total success rate and the time taken, in seconds, for the report to be generated.
+This section contains the total number of tests run and reports the number of errors and failures. It displays the total success rate and the time taken, in seconds, for the report to be generated.
 
 * *Package List*
 +

--- a/website/docs/topics/proc_cli-execute.adoc
+++ b/website/docs/topics/proc_cli-execute.adoc
@@ -10,7 +10,7 @@ You can run {ProductShortName} against your application.
 .Procedure
 
 . Open a terminal and navigate to the `<MTA_HOME>/bin/` directory.
-. Execute the `mta-cli` script, or `mta-cli.bat` for Windows, and specify the appropriate arguments:
+. Run the `mta-cli` script, or `mta-cli.bat` for Windows, and specify the appropriate arguments:
 +
 [source,terminal]
 ----
@@ -144,7 +144,7 @@ $ <MTA_HOME>/bin/mta-cli [TAB]
 [id="bash-completion-temporary_{context}"]
 === Enabling Bash completion
 
-To enable Bash completion for the current shell, execute the following command:
+To enable Bash completion for the current shell, run the following command:
 
 [source,terminal]
 ----
@@ -174,7 +174,7 @@ source <MTA_HOME>/bash-completion/mta-cli
 [id="accessing-help_{context}"]
 == Accessing {ProductShortName} help
 
-To see the complete list of available arguments for the `mta-cli` command, open a terminal, navigate to the `<MTA_HOME>` directory, and execute the following command:
+To see the complete list of available arguments for the `mta-cli` command, open a terminal, navigate to the `<MTA_HOME>` directory, and run the following command:
 
 [source,terminal]]
 ----


### PR DESCRIPTION
MTA 5.2.1 Resolves later requirements of https://issues.redhat.com/browse/WINDUP-3196

Previews:
1. Release notes (complete): http://file.emea.redhat.com/rhoch/06122021/release_notes/html-single/
2. Eclipse guide -- prerequisites for both connected and disconnected environments: http://file.emea.redhat.com/rhoch/06122021/eclipse/html-single/#eclipse-installing-plugin-connected-environment_eclipse-code-ready-studio-guide