### PR TITLE
MTA Eclipse guide: fixed missing icon problem

### DIFF
--- a/docs/topics/eclipse-configuring-run.adoc
+++ b/docs/topics/eclipse-configuring-run.adoc
@@ -15,7 +15,7 @@ You can create multiple run configurations. Each run configuration must have a u
 
 .Procedure
 
-. In the *Issue Explorer*, click the {ProductShortName} icon (image:windup.png[{ProductShortName} button]) to create a run configuration.
+. In the *Issue Explorer*, click the {ProductShortName} icon (image:mta_icon.png[{ProductShortName} button]) to create a run configuration.
 . On the *Input* tab, complete the following fields:
 .. Select a migration path.
 .. Beside the *Projects* field, click *Add* and select one or more projects.


### PR DESCRIPTION
MTA 5.2.1
An image in the Eclipse guide did not appear because an incorrect file name appeared in the document.  
This PR resolves that problem. 