### PR TITLE
IntelliJ IDEA plugin guide: Intro

### DIFF
--- a/docs/eclipse-code-ready-studio-guide/master.adoc
+++ b/docs/eclipse-code-ready-studio-guide/master.adoc
@@ -1,10 +1,17 @@
-include::topics/templates/document-attributes.adoc[]
-[id="eclipse-code-ready-studio-guide"]
-= Eclipse and Red Hat CodeReady Studio Guide
-
 :toc:
+:toclevels: 4
+:numbered:
+
+:imagesdir: topics/images
 :context: eclipse-code-ready-studio-guide
 :eclipse-code-ready-studio-guide:
+:AddonType: plugin
+:IDEName: Eclipse and Red Hat CodeReady Studio
+
+include::topics/templates/document-attributes.adoc[]
+
+[id="eclipse-code-ready-studio-guide"]
+= Eclipse and Red Hat CodeReady Studio Guide
 
 //Inclusive language statement
 include::topics/making-open-source-more-inclusive.adoc[]
@@ -12,7 +19,8 @@ include::topics/making-open-source-more-inclusive.adoc[]
 [id="introduction_{context}"]
 == Introduction
 
-include::topics/eclipse-about-plugin.adoc[leveloffset=+2]
+include::topics/about-ide-addons.adoc[leveloffset=+2]
+
 include::topics/what-is-the-toolkit.adoc[leveloffset=+2]
 
 [id="installing-plugin_{context}"]

--- a/docs/getting-started-guide/master.adoc
+++ b/docs/getting-started-guide/master.adoc
@@ -40,21 +40,6 @@ include::topics/jdk-hardware-mac-prerequisites.adoc[leveloffset=+2]
 // About the Tools
 include::topics/about-tools.adoc[leveloffset=+1]
 
-// About the {CLIName}
-include::topics/about-cli.adoc[leveloffset=+2]
-
-// About the {WebNameTitle}
-include::topics/about-the-web-console.adoc[leveloffset=+2]
-
-// About the {PluginNameTitle}
-include::topics/eclipse-about-plugin.adoc[leveloffset=+2]
-
-// About the VS Code extension
-include::topics/about-vscode-extension.adoc[leveloffset=+2]
-
-// About the {MavenNameTitle}
-include::topics/about-maven.adoc[leveloffset=+2]
-
 == Planning your application migration
 
 // Goals of Assessing a Migration

--- a/docs/intellij-idea-plugin-guide/master.adoc
+++ b/docs/intellij-idea-plugin-guide/master.adoc
@@ -1,13 +1,16 @@
-
 :toc:
 :toclevels: 4
 :numbered:
 
-include::topics/templates/document-attributes.adoc[]
+
 
 :imagesdir: topics/images
-:context: idea-plugin
-:idea-plugin:
+:context: idea-plugin-guide
+:idea-plugin-guide:
+:AddonType: plugin
+:IDEName: IntelliJ IDEA
+
+include::topics/templates/document-attributes.adoc[]
 
 [id="intellij-idea-plugin-guide"]
 = IntelliJ IDEA Plugin Guide
@@ -18,8 +21,8 @@ include::topics/making-open-source-more-inclusive.adoc[]
 [id="introduction"]
 == Introduction
 
-// About the VS Code extension
-// include::topics/about-vscode-extension.adoc[leveloffset=+2]
+// About the IntelliJ IDEA plugin
+include::topics/about-ide-addons.adoc[leveloffset=+2]
 
 // About {ProductName}
 include::topics/what-is-the-toolkit.adoc[leveloffset=+2]
@@ -45,4 +48,4 @@ You can analyze your projects with the {ProductShortName} extension by creating 
 
 // include::topics/vs-code-extension-resolving-issues.adoc[leveloffset=+2]
 
-:!idea-plugin:
+:!idea-plugin-guide:

--- a/docs/topics/about-cli.adoc
+++ b/docs/topics/about-cli.adoc
@@ -1,13 +1,8 @@
 // Module included in the following assemblies:
 //
 // * docs/cli-guide/master.adoc
-// * docs/getting-started-guide/master.adoc
 
 [id="about-cli_{context}"]
 = About the {CLINameTitle}
 
-The {CLIName} is a command-line tool in the {ProductName} that allows users to assess and prioritize migration and modernization efforts for applications. It provides numerous reports that highlight the analysis without the overhead of the other tools. The {CLIName} includes a wide array of customization options, and allows you to finely tune {ProductShortName} analysis options or integrate with external automation tools.
-
-ifndef::cli-guide[]
-For more information on using the {CLIName}, see the {ProductShortName} link:{ProductDocUserGuideURL}[_{UserCLIBookName}_].
-endif::cli-guide[]
+Assess and prioritize migration and modernization efforts for applications by using the {CLIName} tool. The tool includes a wide array of customization option and provides numerous reports that highlight the analysis without the overhead of a graphical user interface.

--- a/docs/topics/about-ide-addons.adoc
+++ b/docs/topics/about-ide-addons.adoc
@@ -1,0 +1,16 @@
+// Module included in the following assemblies:
+//
+// * docs/vs-code-extension-guide/master.adoc
+// * docs/intellij-idea-plugin-guide/master.adoc
+// * docs/eclipse-code-ready-guide/master.adoc
+
+[id="about-ide-addons_{context}"]
+= About the {ProductShortName} {AddonType} for {IDEName}
+
+Migrate and modernize applications by using the {ProductName} ({ProductShortName}) {AddonType} for {IDEName}.
+
+The {ProductShortName} {AddonType} analyzes your projects using customizable rulesets, marks issues in the source code, provides guidance to fix the issues, and offers automatic code replacement, if possible.
+
+ifdef::intellij-idea-plugin-guide[]
+The {IDEName} {AddonType} comes in two versions: Community Edition and Ultimate.
+endif::[]

--- a/docs/topics/about-intellij-idea-plugin.adoc
+++ b/docs/topics/about-intellij-idea-plugin.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assemblies:
+//
+// * docs/intellij-idea-plugin-guide/master.adoc
+
+[id='about-intellij-idea-plugin_{context}']
+= About the {ProductShortName} plugin for IntelliJ IDEA
+
+The {ProductName} ({ProductShortName}) plugin for IntelliJ IDEA helps you migrate and modernize applications.
+
+The {ProductShortName} plugin analyzes your projects using customizable rulesets, marks issues in the source code, provides guidance to fix the issues, and offers Quick Fixes, automatic code replacement, if possible.

--- a/docs/topics/about-maven.adoc
+++ b/docs/topics/about-maven.adoc
@@ -1,9 +1,10 @@
 // Module included in the following assemblies:
 //
 // * docs/maven-guide/master.adoc
+// * docs/getting-started-guide/master.adoc
 
 [id="about-maven_{context}"]
-= About the {MavenNameTitle}
+= About the {MavenName}
 
 The {MavenName} for the {ProductName} integrates into the Maven build process, allowing developers to continuously evaluate migration and modernization efforts with each iteration of source code. It provides numerous reports that highlight the analysis results, and is designed for developers who want updates with each build.
 

--- a/docs/topics/about-the-web-console.adoc
+++ b/docs/topics/about-the-web-console.adoc
@@ -5,8 +5,4 @@
 [id="about-the-web-console_{context}"]
 = About the {WebName}
 
-The {WebName} for the {ProductName} allows a team of users to assess and prioritize migration and modernization efforts for a large number of applications. It allows you to group applications into projects for analysis and provides numerous reports that highlight the results.
-
-ifndef::web-console-guide[]
-For more information on using the {WebName}, see the {ProductShortName} link:{ProductDocWebConsoleGuideURL}[_{WebConsoleBookName}_].
-endif::web-console-guide[]
+Assess and prioritize migration and modernization efforts for a large number of applications by using the {WebName} for the {ProductName}. You can use the {WebName} to group applications into projects for analysis and provides numerous reports that highlight the results.

--- a/docs/topics/about-tools.adoc
+++ b/docs/topics/about-tools.adoc
@@ -1,14 +1,22 @@
 // Module included in the following assemblies:
 //
-// * docs/cli-guide/master.adoc
+// * docs/getting-started-guide/master.adoc
 
 [id="about-tools_{context}"]
 = About the tools
 
-The {ProductName} ({ProductShortName}) provides several tools to assist you in the various stages of your migration and modernization efforts. Review the details of each tool to determine which is right for your project.
+You can use the following {ProductName} ({ProductShortName}) tools to help you migrate and modernize projects:
 
-* CLI
-* Web console
-* {PluginName} for Eclipse and Red Hat CodeReady Studio
-* {ProductShortName} extension for Visual Studio Code
-* {MavenName}
+* link:{ProductDocUserGuideURL}[CLI]: Assess and prioritize migration and modernization efforts for applications without the overhead of a graphical user interface by using the {CLIName} tool.
+* link:{ProductDocWebConsoleGuideURL}[Web console]: Group applications into projects for analysis by using the {ProductShortName} web console.
+* Add-ons for IDEs:
++
+** link:{EclipseCrsGuideURL}[Eclipse and Red Hat CodeReady Studio]
+** link: [IntelliJ IDEA]
+** link:{ProductDocVscGuideURL}[Microsoft Visual Studio Code and Visual Studio Codespaces]
++
+The add-ons mark issues in the source code, provide guidance to fix any issues, and offer automatic code replacement, if possible.
+
+* link:{ProductDocMavenGuideURL}[Maven plugin]:
+
+Ealuate migration and modernization efforts with each iteration of source code by using the {ProductShortName} Maven plugin, which integrates into the Maven build process.

--- a/docs/topics/about-vscode-extension.adoc
+++ b/docs/topics/about-vscode-extension.adoc
@@ -6,12 +6,8 @@
 [id='about-vscode-extension_{context}']
 = About the {ProductShortName} extension for Visual Studio Code
 
-The {ProductName} ({ProductShortName}) extension for Visual Studio Code helps you migrate and modernize applications.
+Migrate and modernize applications by using the {ProductName} ({ProductShortName}) extension for Visual Studio Code.
 
-The {ProductShortName} extension is also compatible with Visual Studio Codespaces, the Microsoft cloud-hosted development environment.
+The {ProductShortName} extension is compatible with Visual Studio Codespaces, the Microsoft cloud-hosted development environment.
 
 The {ProductShortName} extension analyzes your projects using customizable rulesets, marks issues in the source code, provides guidance to fix the issues, and offers automatic code replacement, if possible.
-
-ifdef::getting-started-guide[]
-For more information about using the {ProductShortName} extension, see the {ProductShortName} link:{ProductDocVscGuideURL}[_Visual Studio Code Extension Guide_].
-endif::[]

--- a/docs/topics/eclipse-about-plugin.adoc
+++ b/docs/topics/eclipse-about-plugin.adoc
@@ -1,19 +1,10 @@
 // Module included in the following assemblies:
 //
-// * docs/getting-started-guide/master.adoc
 // * docs/eclipse-code-ready-studio-guide/master.adoc
 
 [id="eclipse-about-plugin_{context}"]
 = About the {PluginName} for Eclipse and Red Hat CodeReady Studio
 
-The {ProductName} ({ProductShortName}) plugin for Eclipse and Red Hat CodeReady Studio helps you migrate and modernize applications.
+Analyze your projects by using the {ProductName} ({ProductShortName}) plugin for Eclipse and Red Hat CodeReady Studio.
 
 The {PluginName} analyzes your projects using customizable rulesets, marks migration issues in the source code, provides guidance to fix the issues, and offers automatic code replacement, or Quick Fixes, if possible.
-
-ifdef::eclipse-code-ready-studio-guide[]
-For information about a similar extension for Visual Studio Code, see the link:{ProductDocVscGuideURL}[_Visual Studio Code Extension Guide_].
-endif::[]
-
-ifdef::getting-started-guide[]
-For more information on using the {PluginName}, see the MTA link:{EclipseCrsGuideURL}[_{EclipseCrsGuideTitle}_].
-endif::[]

--- a/docs/topics/features.adoc
+++ b/docs/topics/features.adoc
@@ -3,24 +3,28 @@
 // * docs/getting-started-guide/master.adoc
 
 [id="features_{context}"]
-= {ProductShortName} Features
+= {ProductShortName} features
 
-The {ProductName} ({ProductShortName}) provides a number of capabilities to assist with planning and executing migration projects.
+Plan and perform your migration and modernization projects more efficiently by using {ProductName} ({ProductShortName}) features.
 
 Planning and work estimation::
-{ProductShortName} assists project managers by detailing the type of work and estimation of effort to complete the tasks. Level of effort is represented in {ProductShortName} reports as story points. Actual estimates will be based on the skills required and the classification of migration work needed.
+Plan work efforts by using the story point estimates that appear in {ProductShortName} reports.
 
-Identifying migration issues and providing solutions::
-{ProductShortName} identifies migration issues and highlights specific points in the code where an issue occurs. {ProductShortName} suggests code changes and provides additional resources to help engineers resolve the specific issue.
+Identifying issues and providing solutions::
+Identify specific lines of code that might cause migration or modernization issues. {ProductShortName} suggests code changes and provides additional resources to help you resolve problems.
 
 Detailed reporting::
-{ProductShortName} produces numerous reports to give both high-level views of the migration effort and details of specific migration tasks. You can view migration issues across all applications, charts and summary information about issues in an application, a breakdown of issues by module in the application, reports of technologies used, and dependencies on other applications and services. You can also examine source files to see the line of code where an issue occurs. See the link:{ProductDocUserGuideURL}[_{UserCLIBookName}_] for more information on the available {ProductShortName} reports.
+View reports that give a high-level view of the efforts needed to complete your project as well as the ability to drill down to specifics such as the dependencies of your applications on other applications and services.
++
+For more information on the available {ProductShortName} reports, see the link:{ProductDocUserGuideURL}[_{UserCLIBookName}_] .
 
 Built-in rules and migration paths::
-{ProductShortName} comes with a core set of rules to provide migration assistance for several common migration paths. These rules identify the use of proprietary functionality from other application servers or deprecated subsystems from previous versions of JBoss EAP. {ProductShortName} also contains rules to identify common migration issues, such as hard-coded IP addresses and JNDI lookups.
+Use the rulesets supplied with {ProductShortName} to identify the use of proprietary functionality from other application servers or from deprecated versions of JBoss EAP and other targets.
 
 Rule extensibility and customization::
-{ProductShortName} provides the ability to create powerful and complex rules. You can expand upon the core set of rules provided by {ProductShortName} and create rules to identify additional issues that are important for your migration project. You can also override core rules and create custom rule categories. See the link:{ProductDocRulesGuideURL}[_{RulesDevBookName}_] for more information on customizing {ProductShortName} rules.
+Create powerful and complex rules to identify issues beyond those addressed by the rulesets included in {ProductShortName} and then add these rules to your {ProductShortName} configuration to analyze your projects.
++
+For more information on customizing {ProductShortName} rules, see the link:{ProductDocRulesGuideURL}[_{RulesDevBookName}_].
 
 Ability to analyze source code or application archives::
-{ProductShortName} can evaluate application archives or source code, and can evaluate multiple applications together. It can identify archives that are shared across multiple applications, which can help with more accurate effort estimation.
+Evaluate source code or application archives, including those shared across multiple applications using {ProductShortName}.

--- a/docs/topics/making-open-source-more-inclusive.adoc
+++ b/docs/topics/making-open-source-more-inclusive.adoc
@@ -1,14 +1,3 @@
-// Module included in the following assemblies:
-//
-// * docs/cli-guide/master.adoc
-// * docs/getting-started-guide/master.adoc
-// * docs/maven-guide/master.adoc
-// * docs/eclipse-code-ready-studio-guide/master.adocs
-// * docs/release-notes/release_notes-5.0/master.adoc
-// * docs/release-notes/release_notes-5.1/master.adoc
-// * docs/rules-development-guide/master.adoc
-// * docs/web-console-guide/master.adoc
-
 [preface]
 [id="making-open-source-more-inclusive_{context}"]
 = Making open source more inclusive

--- a/docs/topics/method-deploy.adoc
+++ b/docs/topics/method-deploy.adoc
@@ -5,7 +5,7 @@
 [id="method-deploy_{context}"]
 = Deploy phase
 
-.Red Hat migration methodology: Deploy phase
+.Red Hat migration methodology: deploy phase
 image::RHAMT_AMM_Methodology_446947_0617_ECE_Deploy.png[Red Hat migration methodology: Deploy]
 
 The _Deploy_ phase is when you run the plan created in the Design phase. In this phase, you scale the overall transformation process to complete the plan and bring all applications to their new production environment.

--- a/docs/topics/method-design.adoc
+++ b/docs/topics/method-design.adoc
@@ -5,8 +5,8 @@
 [id="method-design_{context}"]
 = Design phase
 
-.Red Hat migration methodology: Design phase
-image::RHAMT_AMM_Methodology_446947_0617_ECE_Design.png[Red Hat migration methodology: Design]
+.Red Hat migration methodology: design phase
+image::RHAMT_AMM_Methodology_446947_0617_ECE_Design.png[Red Hat migration methodology: design]
 
 The _Design_ phase is when you identify all risks, define a strategy and target architecture, prove the technology, and build the business case. This phase consists of the following steps:
 

--- a/docs/topics/templates/document-attributes.adoc
+++ b/docs/topics/templates/document-attributes.adoc
@@ -29,6 +29,7 @@
 :MavenName: Maven plugin
 :MavenNameTitle: Maven Plugin
 
+
 // ****************
 // * Doc metadata *
 // ****************
@@ -68,7 +69,7 @@
 :ocp-first: {ocp-full} (RHOCP)
 :ProductDocUserGuideURL: https://access.redhat.com/documentation/en-us/{DocInfoProductNameURL}/{DocInfoProductNumber}/html-single/cli_guide
 :ProductDocRulesGuideURL: https://access.redhat.com/documentation/en-us/{DocInfoProductNameURL}/{DocInfoProductNumber}/html-single/rules_development_guide
-:EclipseCrsGuideURL: https://access.redhat.com/documentation/en-us/{DocInfoProductNameURL}/{DocInfoProductNumber}/html-single/eclipse_and_red_hat_code_ready_studio_plugin_guide
+:EclipseCrsGuideURL: https://access.redhat.com/documentation/en-us/{DocInfoProductNameURL}/{DocInfoProductNumber}/html-single/eclipse_and_red_hat_codeready_studio_guide
 :ProductDocIntroToMTAGuideURL: https://access.redhat.com/documentation/en-us/{DocInfoProductNameURL}/{DocInfoProductNumber}/html-single/introduction_to_the_migration_toolkit_for_applications
 :ProductDocWebConsoleGuideURL: https://access.redhat.com/documentation/en-us/{DocInfoProductNameURL}/{DocInfoProductNumber}/html-single/web_console_guide
 :ProductDocMavenGuideURL: https://access.redhat.com/documentation/en-us/{DocInfoProductNameURL}/{DocInfoProductNumber}/html-single/maven_plugin_guide

--- a/docs/vs-code-extension-guide/master-docinfo.xml
+++ b/docs/vs-code-extension-guide/master-docinfo.xml
@@ -1,9 +1,9 @@
-<title>Visual Studio Code Extension Guide</title>
+<title>Visual Studio Code and Visual Studio Codespaces Extension Guide Extension Guide</title>
 <productname>{DocInfoProductName}</productname>
 <productnumber>{DocInfoProductNumber}</productnumber>
 <subtitle>Identify and resolve migration issues by analyzing your applications with the {ProductName} extension for Visual Studio Code.</subtitle>
 <abstract>
-    <para>This guide describes how to use the {ProductName} extension for Visual Studio Code to simplify the migration of Java applications.</para>
+    <para>This guide describes how to use the {ProductName} extension for Visual Studio Code and Visual Studio Codespaces Extension Guide to simplify the migration of Java applications.</para>
 </abstract>
 <authorgroup>
     <orgname>Red Hat Customer Content Services</orgname>

--- a/docs/vs-code-extension-guide/master.adoc
+++ b/docs/vs-code-extension-guide/master.adoc
@@ -2,13 +2,15 @@
 :toclevels: 4
 :numbered:
 
-include::topics/templates/document-attributes.adoc[]
-
 :imagesdir: topics/images
 :context: vsc-extension-guide
-:vsc-extension-guide-guide:
+:vsc-extension-guide:
+:AddonType: extension
+:IDEName: Microsoft Visual Code Studio and Visual Studio Codespaces
 
-= Visual Studio Code Extension Guide
+include::topics/templates/document-attributes.adoc[]
+
+= Visual Studio Code and Visual Studio Codespaces Extension Guide
 
 //Inclusive language statement
 include::topics/making-open-source-more-inclusive.adoc[]
@@ -16,7 +18,7 @@ include::topics/making-open-source-more-inclusive.adoc[]
 == Introduction
 
 // About the VS Code extension
-include::topics/about-vscode-extension.adoc[leveloffset=+2]
+include::topics/about-ide-addons.adoc[leveloffset=+2]
 
 // About {ProductName}
 include::topics/what-is-the-toolkit.adoc[leveloffset=+2]

--- a/docs/web-console-guide/master.adoc
+++ b/docs/web-console-guide/master.adoc
@@ -64,7 +64,7 @@ include::topics/web-openshift-insufficient-resources.adoc[leveloffset=+4]
 
 ===== Reporting issues
 
-{ProductShortName} uses Jira as its issue tracking system. If you encounter an issue executing {ProductShortName}, submit a link:{JiraWindupURL}[Jira issue].
+{ProductShortName} uses Jira as its issue tracking system. If you encounter an issue running {ProductShortName}, submit a link:{JiraWindupURL}[Jira issue].
 
 == Using the {WebName} to analyze applications
 

--- a/index.md
+++ b/index.md
@@ -9,5 +9,5 @@ layout: default
 - [Eclipse and Red Hat CodeReady Studio Guide](docs/eclipse-code-ready-studio-guide/master/index.html)
 - [ItelliJ IDEA Plugin Guide](docs/intellij-idea-plugin-guide/master/index.html)
 - [Release Notes](docs/release-notes/master/index.html)
-- [Visual Studio Code Extension Guide](docs/vs-code-extension-guide/master/index.html)
+- [Visual Studio Code and Visual Studio Codespaces Extension Guide](docs/vs-code-extension-guide/master/index.html)
 - [Introduction to the Migration Toolkit for Applications](docs/getting-started-guide/master/index.html)


### PR DESCRIPTION
MTA 5.2.1.

Partially resolves https://issues.redhat.com/browse/WINDUP-3207

This PR includes the introductory chapter of the IntelliJ IDEA plugin guide and changes to the Tools chapter of  _Introduction to the Migration Toolkit for Apllications_.

The PR also includes minor capitalization chages in  _Introduction to the Migration Toolkit for Apllications_.

Previews:
1. Introduction to the IntelliJ plugin guide: https://deploy-preview-504--windup-documentation.netlify.app/docs/intellij-idea-plugin-guide/master/index.html#introduction

2. The tools chapter of of  _Introduction to the Migration Toolkit for Apllications_:  https://deploy-preview-504--windup-documentation.netlify.app/docs/getting-started-guide/master/index.html#about-tools_getting-started-guide