### PR TITLE
IntelliJ IDEA guide: installation chapter

### DIFF
--- a/docs/intellij-idea-plugin-guide/master.adoc
+++ b/docs/intellij-idea-plugin-guide/master.adoc
@@ -26,7 +26,7 @@ include::topics/about-ide-addons.adoc[leveloffset=+2]
 include::topics/what-is-the-toolkit.adoc[leveloffset=+2]
 
 // Install the extension
-// include::topics/installing-intellij-idea-plugin.adoc[leveloffset=+1]
+include::topics/installing-intellij-idea-plugin.adoc[leveloffset=+1]
 
 [id="analyzing-projects-with-idea-plugin"]
 == Analyzing your projects with the {ProductShortName} plugin

--- a/docs/topics/installing-intellij-idea-plugin.adoc
+++ b/docs/topics/installing-intellij-idea-plugin.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assemblies:
+//
+// * docs/intellij-idea-plugin-guide/master.adoc
+
+[id="intellij-idea-plugin-extension_{context}"]
+= Installing the {ProductShortName} extension for IntelliJ IDEA
+
+You can install the {ProductShortName} extension in the Ultimate and the Community Edition releases of IntelliJ IDEA.
+
+.Prerequisites
+include::snippet_jdk-hardware-mac-prerequisites.adoc[]
+
+* The latest version of `mta-cli` from the link:{MTADownloadPageURL}[{ProductShortName} download page]
+
+.Procedure
+
+. In IntelliJ IDEA, click *Plugins* on the Activity bar.
+. Enter `{ProductName}` in the Search field on the *Marketplace* tab.
+. Select the *Migration Toolkit for Applications (MTA) by Red Hat* plugin and click *Install*.
++
+The plugin is listed on the *Installed* tab.


### PR DESCRIPTION
MTA 5.2.1

Partially resolves https://issues.redhat.com/browse/WINDUP-3207

This PR contains the text of the installation chapter of the IntelliJ IDEA plugin guide.

Preview of installation chapter: https://deploy-preview-505--windup-documentation.netlify.app/docs/intellij-idea-plugin-guide/master/index.html#intellij-idea-plugin-extension_idea-plugin

John, just so you know, this PR includes a change to the way the repo calls the prerequisites for installing the IDEs and other add-ons. You can ignore changes to every file in this PR except installing-intellij-plugin.adoc. 