### PR TITLE
IntelliJ IDEA guide: usage

### DIFF
--- a/docs/intellij-idea-plugin-guide/master.adoc
+++ b/docs/intellij-idea-plugin-guide/master.adoc
@@ -31,11 +31,9 @@ include::topics/installing-intellij-idea-plugin.adoc[leveloffset=+1]
 [id="analyzing-projects-with-idea-plugin"]
 == Analyzing your projects with the {ProductShortName} plugin
 
-You can analyze your projects with the {ProductShortName} extension by creating a run configuration and running an analysis.
+You can analyze your projects with the {ProductShortName} plugin by creating a run configuration and running an analysis.
 
-// include::topics/vs-code-extension-interface.adoc[leveloffset=+2]
-
-// include::topics/vs-code-extension-run-configuration.adoc[leveloffset=+2]
+include::topics/intellij-idea-plugin-run-configuration.adoc[leveloffset=+2]
 
 [id="reviewing-and-resolving-migration-issues"]
 == Reviewing and resolving migration issues

--- a/docs/topics/intellij-idea-plugin-run-configuration.adoc
+++ b/docs/topics/intellij-idea-plugin-run-configuration.adoc
@@ -1,0 +1,40 @@
+// Module included in the following assemblies:
+//
+// * docs/intellij-idea-plugin-guide/master.adoc
+
+[id="intellij-idea-plugin-run-configuration_{context}"]
+= Creating a run configuration
+
+You can create multiple run configurations to run against each project you import to IntelliJ IDEA.
+
+.Procedure
+
+. In the *Projects* view, click the project you want to analyze.
+. On the left side of the screen, click the *{ProductName}* tab.
++
+If this is your first configuration, the run configuration panel is displayed on the right.
+
+. If this is not your first configuration, right-click configuration in the list and select *New configuration*.
++
+The run configuration panel is displayed on the right.
+
+. Complete the following configuration fields:
+
+** *mta-cli*: Click *Add*, select the filepath, and click *Save*.
+** *Input*: Click *Add* and enter the input file or directory.
+** *Target*: Select one or more target migration paths.
++
+[NOTE]
+====
+The location shown in the *Output* is set by the plugin.
+====
+
+. In the list of configurations, right-click the new configuration and select *Run Analysis*.
++
+The *Console (MTA)* terminal emulator opens, displaying information about the progress of the analysis.
++
+When the analysis is completed, you can click either *Report* or *Results* below the name of the configuration file you ran.
+
+** *Reports* opens the MTA report, which describes any issues you need to address before you migrate or modernize your application. For more information, see link:{ProductDocUserGuideURL}#review-reports_cli-guide[MTA report] in the _{UserCLIBookName}_.
+
+** *Results* opens a directory displaying hints (issues) per application.


### PR DESCRIPTION
MTA 5.2.1

Partially resolves https://issues.redhat.com/browse/WINDUP-3207

This PR contains the text of the usage (run configuration) chapter of the IntelliJ IDEA plugin guide. the title is parallel with other IDE guides. 

Preview of chapter: https://deploy-preview-516--windup-documentation.netlify.app/docs/intellij-idea-plugin-guide/master/index.html#analyzing-projects-with-idea-plugin