### PR TITLE
Aligning context names with OCP version numbers

### DIFF
--- a/docs/topics/installing-web-console-on-openshift.adoc
+++ b/docs/topics/installing-web-console-on-openshift.adoc
@@ -3,7 +3,7 @@
 // * docs/web-console-guide/master.adoc
 
 [id="installing-web-console-on-openshift_{context}"]
-ifdef::ocp-45[]
+ifdef::ocp-46[]
 = Installing the {WebName} on {ocp-short} 4.6 and later
 
 You can install the {WebName} on {ocp-short} 4.6 and later versions with the {ProductName} Operator.
@@ -13,7 +13,7 @@ You can install the {WebName} on {ocp-short} 4.6 and later versions with the {Pr
 The {ProductName} Operator is a Community Operator. Red Hat provides no support for Community Operators.
 ====
 endif::[]
-ifdef::ocp-41[]
+ifdef::ocp-42[]
 = Installing the {WebName} on {ocp-short} 4.2-4.5
 
 You can install the {WebName} on {ocp-short} 4.2-4.5 by importing a template and instantiating it to create the {WebName} application.
@@ -21,7 +21,7 @@ endif::[]
 
 .Prerequisites
 
-ifdef::ocp-45,ocp-41[]
+ifdef::ocp-46,ocp-42[]
 * 4 vCPUs, 8 GB RAM, and 40 GB persistent storage.
 * One or more projects in which you can install the {WebName}.
 endif::[]
@@ -31,18 +31,18 @@ endif::[]
 Do not install the {WebName} in a default project.
 ====
 
-ifdef::ocp-45[]
+ifdef::ocp-46[]
 * `cluster-admin` privileges to install the {DocInfoProductName} Operator.
 * `project-admin-user` privileges to install the {WebName} application in a project.
 endif::[]
 
-ifdef::ocp-41[]
+ifdef::ocp-42[]
 .Procedure
 
 . Navigate to the link:{MTADownloadPageURL}[{ProductShortName} Download page] and download the {WebName} `Local install & OpenShift` file.
 . Extract the `.zip` file to a directory, for example, `MTA_HOME`.
 endif::[]
-ifdef::ocp-45[]
+ifdef::ocp-46[]
 .Installing the {DocInfoProductName} Operator
 
 . Log in to the OpenShift web console as a user with `cluster-admin` privileges.
@@ -60,7 +60,7 @@ ifdef::ocp-45[]
 . Click the *{DocInfoProductName}* Operator.
 . Click *Create*.
 endif::[]
-ifdef::ocp-41[]
+ifdef::ocp-42[]
 . Launch the OpenShift web console.
 . Click the *Import YAML* button in the upper-right corner of the web console.
 . Select *mta* from the *Project* list.
@@ -74,7 +74,7 @@ Two templates are provided, one for shared storage and one without shared storag
 . Click the *{ProductName}* template.
 . Click *Instantiate Template*.
 endif::[]
-ifdef::ocp-45,ocp-41[]
+ifdef::ocp-46,ocp-42[]
 . Review the application settings and click *Create*.
 . In the *Topology* view, click the `mta-web-console` application and then click the *Resources* tab.
 . Click the `secure-mta-web-console` route to open the {WebName} in a new browser window.

--- a/docs/web-console-guide/master.adoc
+++ b/docs/web-console-guide/master.adoc
@@ -38,14 +38,14 @@ You can install the {WebName} on {ocp-short} 4.6 and later versions with the {Pr
 You can install the {WebName} on {ocp-short} 4.2-4.5 by importing a template and instantiating it to create the {WebName} application.
 
 :web-console-guide!:
-:context: ocp-45
-:ocp-45:
+:context: ocp-46
+:ocp-46:
 include::topics/installing-web-console-on-openshift.adoc[leveloffset=+3]
-:ocp-45!:
-:context: ocp-41
-:ocp-41:
+:ocp-46!:
+:context: ocp-42
+:ocp-42:
 include::topics/installing-web-console-on-openshift.adoc[leveloffset=+3]
-:ocp-41!:
+:ocp-42!:
 :web-console-guide:
 ==== Troubleshooting a {WebName} installation on OpenShift
 


### PR DESCRIPTION
MTA 5.2.1+

The procedure for installing the MTA web console on OCP varies with the OCP version. Originally, there was one set of instructions for OCP 4.1-4.4 and another for 4.5+. To make full use of modularization, two context variables were introduced in the  document's files, `ocp-41` and `ocp-45`. As the product matures, the first set of instructions was applied to OCP version 4.2-4.5 and the second to version 4.6+. The text of the document was changed but the context variables were not. Since the variables are simply names, they had no impact on the document, but unless one knows the history of the document, it is not clear why `ocp-41` refers to OCP versions 4.2-4.5 and `ocp-45` refers to OCP version 4.6+. This PR changes the names of the variables to `ocp-42` and `ocp-46` respectively. 

This change has no effect on the document from the user's perspective; it simply clears up a small inconsistency in the context attributes. 

The document builds correctly.

Preview: https://deploy-preview-519--windup-documentation.netlify.app/docs/web-console-guide/master/index.html#installing-the-web-console {the installation chapter, the only place where the different context attributes are used].

I confirm that this pull request was submitted according to the [contribution guidelines](https://github.com/oVirt/ovirt-site/blob/master/CONTRIBUTING.md): @RichardHoch

This pull request needs review by @stoobie. 