### PR TITLE
Change extension to plugin in IntelliJ

### DIFF
--- a/docs/intellij-idea-plugin-guide/master.adoc
+++ b/docs/intellij-idea-plugin-guide/master.adoc
@@ -25,7 +25,7 @@ include::topics/about-ide-addons.adoc[leveloffset=+2]
 // About {ProductName}
 include::topics/what-is-the-toolkit.adoc[leveloffset=+2]
 
-// Install the extension
+// Install the plugin
 include::topics/installing-intellij-idea-plugin.adoc[leveloffset=+1]
 
 [id="analyzing-projects-with-idea-plugin"]

--- a/docs/topics/installing-intellij-idea-plugin.adoc
+++ b/docs/topics/installing-intellij-idea-plugin.adoc
@@ -4,9 +4,9 @@
 
 :_content-type: PROCEDURE
 [id="intellij-idea-plugin-extension_{context}"]
-= Installing the {ProductShortName} extension for IntelliJ IDEA
+= Installing the {ProductShortName} plugin for IntelliJ IDEA
 
-You can install the {ProductShortName} extension in the Ultimate and the Community Edition releases of IntelliJ IDEA.
+You can install the {ProductShortName} plugin in the Ultimate and the Community Edition releases of IntelliJ IDEA.
 
 .Prerequisites
 include::snippet_jdk-hardware-mac-prerequisites.adoc[]


### PR DESCRIPTION
Changed "extension" to "plugin" where needed in IntelliJ user guide