### PR TITLE
WINDUP-3338: Only Open JDK 11 and Oracle JDK 11 are supported

### DIFF
--- a/docs/topics/snippet_jdk-hardware-mac-prerequisites.adoc
+++ b/docs/topics/snippet_jdk-hardware-mac-prerequisites.adoc
@@ -1,9 +1,7 @@
 :_content-type: SNIPPET
 * Java Development Kit (JDK) installed. {ProductShortName} supports the following JDKs:
 
-** OpenJDK 1.8
 ** OpenJDK 11
-** Oracle JDK 1.8
 ** Oracle JDK 11
 
 * 8 GB RAM

--- a/docs/topics/system-requirements.adoc
+++ b/docs/topics/system-requirements.adoc
@@ -8,9 +8,7 @@
 
 * One of the following Java Development Kits (JDKs):
 
-** OpenJDK 1.8
 ** OpenJDK 11
-** Oracle JDK 1.8
 ** Oracle JDK 11
 
 * 8 GB RAM


### PR DESCRIPTION
MTA 5.3.0

Resolves: https://issues.redhat.com/browse/WINDUP-3338

From Release 5.3.0 MTA is no longer compatible with Java 8. Documentation impact: references to OpenJDK 1.8 and Oracle JDK 1.8 need to be removed from the MTA Guides

Previews
1) Prerequisites found in all guides:  

2) Prerequisites in _Introduction to the Migration Toolkit for Applications_ :  