### PR TITLE
Windup 3427 MTA intro

### DIFF
--- a/docs/getting-started-guide/master.adoc
+++ b/docs/getting-started-guide/master.adoc
@@ -48,11 +48,17 @@ include::topics/about-cli.adoc[leveloffset=+2]
 // About the {WebNameTitle}
 include::topics/about-the-web-console.adoc[leveloffset=+2]
 
+//About the {ProductShortName} Operator
+include::topics/about-the-mta-operator.adoc[leveloffset=+2]
+
 // About the {PluginNameTitle}
 include::topics/eclipse-about-plugin.adoc[leveloffset=+2]
 
 // About the VS Code extension
 include::topics/about-vscode-extension.adoc[leveloffset=+2]
+
+//About the IntelliJ plugin
+include::topics/intellij-about-plugin.adoc[leveloffset=+2]
 
 // About the {MavenNameTitle}
 include::topics/about-maven.adoc[leveloffset=+2]

--- a/docs/topics/about-the-mta-operator.adoc
+++ b/docs/topics/about-the-mta-operator.adoc
@@ -1,0 +1,11 @@
+// Module included in the following assemblies:
+//
+// * docs/wgetting-started-guide/master.adoc
+
+:_content-type: CONCEPT
+[id="about-the-mta-operator_{context}"]
+= About the {ProductShortName} Operator
+
+You can install the web console on OpenShift Container Platform 4.6 and later versions with the Migration Toolkit for Applications Operator.
+
+For installation instructions, see link:{ProductDocWebConsoleGuideURL}/index#installing-web-console-on-openshift_ocp-46[Installing the web console on OpenShift Container Platform 4.6 and later].

--- a/docs/topics/about-the-web-console.adoc
+++ b/docs/topics/about-the-web-console.adoc
@@ -1,5 +1,6 @@
 // Module included in the following assemblies:
 //
+// * docs/getting-started-guide/master.adoc
 // * docs/web-console-guide/master.adoc
 
 :_content-type: CONCEPT

--- a/docs/topics/about-tools.adoc
+++ b/docs/topics/about-tools.adoc
@@ -10,6 +10,8 @@ The {ProductName} ({ProductShortName}) provides several tools to assist you in t
 
 * CLI
 * Web console
+* {ProductName} Operator
 * {PluginName} for Eclipse and Red Hat CodeReady Studio
-* {ProductShortName} extension for Visual Studio Code
+* {ProductShortName} extension for Visual Studio Code and Eclipse Che
+* {ProductShortName} plugin for IntelliJ
 * {MavenName}

--- a/docs/topics/about-vscode-extension.adoc
+++ b/docs/topics/about-vscode-extension.adoc
@@ -1,17 +1,18 @@
 // Module included in the following assemblies:
 //
+// * docs/getting-started-guide/master.adoc
 // * docs/vs-code-extension-guide/master.adoc
 
 :_content-type: CONCEPT
 [id='about-vscode-extension_{context}']
-= About the {ProductShortName} extension for Visual Studio Code
+= About the {ProductShortName} extension for Visual Studio Code and Eclipse Che
 
-The {ProductName} ({ProductShortName}) extension for Visual Studio Code helps you migrate and modernize applications.
+The {ProductName} ({ProductShortName}) extension for Visual Studio Code and Eclipse Che helps you migrate and modernize applications.
 
 The {ProductShortName} extension is also compatible with Visual Studio Codespaces, the Microsoft cloud-hosted development environment.
 
 The {ProductShortName} extension analyzes your projects using customizable rulesets, marks issues in the source code, provides guidance to fix the issues, and offers automatic code replacement, if possible.
 
 ifdef::getting-started-guide[]
-For more information about using the {ProductShortName} extension, see the {ProductShortName} link:{ProductDocVscGuideURL}[_Visual Studio Code Extension Guide_].
+For more information about using the {ProductShortName} extension, see the {ProductShortName} link:{ProductDocVscGuideURL}[_Visual Studio Code and Eclipse Che Extension Guide_].
 endif::[]

--- a/docs/topics/intellij-about-plugin.adoc
+++ b/docs/topics/intellij-about-plugin.adoc
@@ -1,0 +1,16 @@
+// Module included in the following assemblies:
+//
+// * docs/getting-started-guide/master.adoc
+// * docs/eclipse-code-ready-studio-guide/master.adoc
+
+:_content-type: CONCEPT
+[id="intellij-about-plugin_{context}"]
+= About the {PluginName} for IntelliJ
+
+The {ProductName} ({ProductShortName}) plugin for IntelliJ helps you migrate and modernize applications.
+
+The {PluginName} analyzes your projects using customizable rulesets, marks migration issues in the source code, provides guidance to fix the issues, and offers automatic code replacement, or Quick Fixes, if possible.
+
+ifdef::getting-started-guide[]
+For more information on using the {PluginName}, see the MTA link:{IntelliJGuideURL}[_{IntelliJBookName}_].
+endif::[]

--- a/docs/topics/migration-paths.adoc
+++ b/docs/topics/migration-paths.adoc
@@ -13,23 +13,25 @@ The {ProductName} ({ProductShortName}) supports migrations from third-party ente
 The following table describes the most common supported migration paths.
 
 .Supported migration paths: Source platform &#8658; target
-[cols="2,^1,^1,^1,^1,^1,^1,^1",options="^,header"]
+[cols="2,^1,^1,^1,^1,^1,^1,^1,^1",options="^,header"]
 |====
 
 |Source platform{nbsp}&#8658;
 |JBoss EAP{nbsp}6
 |JBoss EAP{nbsp}7
 |RHOCP
-|OpenJDK 8{nbsp}&{nbsp}11
+|OpenJDK 8,{nbsp}11,{nbsp}&{nbsp}17
 |Apache Camel{nbsp}3
 |Spring Boot on Red{nbsp}Hat Runtimes
 |Quarkus
+|Azure
 
 |Oracle WebLogic Server
 |{icon-check}
 |{icon-check}
 |{icon-check}
 |{icon-check}
+|-
 |-
 |-
 |-
@@ -43,12 +45,14 @@ The following table describes the most common supported migration paths.
 |-
 |-
 |-
+|-
 
 |JBoss EAP 4
 |{icon-check}
 |{icon-x} footnoteref:[note2,Although {ProductShortName} does not currently provide rules for this migration path, Red Hat Consulting can assist with migration from any source platform to JBoss EAP 7.]
 |{icon-check}
 |{icon-check}
+|-
 |-
 |-
 |-
@@ -61,12 +65,14 @@ The following table describes the most common supported migration paths.
 |-
 |-
 |-
+|-
 
 |JBoss EAP 6
 |N/A
 |{icon-check}
 |{icon-check}
 |{icon-check}
+|-
 |-
 |-
 |-
@@ -79,12 +85,14 @@ The following table describes the most common supported migration paths.
 |-
 |-
 |-
+|{icon-check}
 
 |Oracle JDK
 |-
 |-
 |{icon-check}
 |{icon-check}
+|-
 |-
 |-
 |-
@@ -97,6 +105,7 @@ The following table describes the most common supported migration paths.
 |{icon-check}
 |-
 |-
+|-
 
 |Spring Boot
 |-
@@ -104,6 +113,7 @@ The following table describes the most common supported migration paths.
 |{icon-check}
 |{icon-check}
 |-
+|{icon-check}
 |{icon-check}
 |{icon-check}
 
@@ -115,5 +125,5 @@ The following table describes the most common supported migration paths.
 |-
 |-
 |-
-
+|-
 |====

--- a/docs/topics/templates/document-attributes.adoc
+++ b/docs/topics/templates/document-attributes.adoc
@@ -57,6 +57,7 @@ endif::[]
 :EclipseCrsGuideTitle: Eclipse and Red Hat CodeReady Studio Guide
 :WebConsoleBookName: Web Console Guide
 :MavenBookName: Maven Plugin Guide
+:IntelliJBookName: IntelliJ IDEA Plugin Guide
 
 :ocp-full: Red Hat OpenShift Container Platform
 :ocp-short: OpenShift Container Platform
@@ -83,7 +84,8 @@ endif::[]
 :ProductDocUserGuideURL: https://access.redhat.com/documentation/en-us/{DocInfoProductNameURL}/{DocInfoProductNumber}/html-single/cli_guide
 :ProductDocRulesGuideURL: https://access.redhat.com/documentation/en-us/{DocInfoProductNameURL}/{DocInfoProductNumber}/html-single/rules_development_guide
 :EclipseCrsGuideURL: https://access.redhat.com/documentation/en-us/{DocInfoProductNameURL}/{DocInfoProductNumber}/html-single/eclipse_and_red_hat_codeready_studio_guide
-:ProductDocIntroToMTAGuideURL: https://access.redhat.com/documentation/en-us/{DocInfoProductNameURL}/{DocInfoProductNumber}/html-single/introduction_to_the_{DocInfoProductNameURL}
+:IntelliJGuideURL: https://access.redhat.com/documentation/en-us/{DocInfoProductNameURL}/{DocInfoProductNumber}/html-single/intellij_idea_plugin_guide
+:ProductDocIntroToMTAGuideURL: https://access.redhat.com/documentation/en-us/{DocInfoProductNameURL}/{DocInfoProductNumber}/html-single/introduction_to_the_migration_toolkit_for_applications
 :ProductDocWebConsoleGuideURL: https://access.redhat.com/documentation/en-us/{DocInfoProductNameURL}/{DocInfoProductNumber}/html-single/web_console_guide
 :ProductDocMavenGuideURL: https://access.redhat.com/documentation/en-us/{DocInfoProductNameURL}/{DocInfoProductNumber}/html-single/maven_plugin_guide
 :ProductDocVscGuideURL: https://access.redhat.com/documentation/en-us/{DocInfoProductNameURL}/{DocInfoProductNumber}/html-single/visual_studio_code_extension_guide

--- a/docs/topics/what-is-the-toolkit.adoc
+++ b/docs/topics/what-is-the-toolkit.adoc
@@ -22,7 +22,11 @@ The {ProductName} ({ProductShortName}) is an extensible and customizable rule-ba
 * Migrating from Oracle WebLogic or IBM WebSphere Application Server to Red Hat JBoss Enterprise Application Platform
 * Containerizing applications and making them cloud-ready
 * Migrating from Java Spring Boot to Quarkus
-* Updating from Oracle JDK to OpenJDK
+* Upgrading from OpenJDK 8 to OpenJDK 11
+* Upgrading from OpenJDK 11 to OpenJDK 17
+* Migrating EAP Java applicatons to Azure
+* Migrating Spring Boot Java applications to Azure
+
 
 For more information about use cases and migration paths, see the link:https://developers.redhat.com/products/mta/use-cases[MTA for developers] web page.
 


### PR DESCRIPTION
MTA 6.0
Resolves https://issues.redhat.com/browse/WINDUP-3427. 
Previews:
https://deploy-preview-550--windup-documentation.netlify.app/docs/getting-started-guide/master/index.html#what-is-the-toolkit_getting-started-guide
https://deploy-preview-550--windup-documentation.netlify.app/docs/getting-started-guide/master/index.html#migration-paths_getting-started-guide
https://deploy-preview-550--windup-documentation.netlify.app/docs/getting-started-guide/master/index.html#about-tools_getting-started-guide
https://deploy-preview-550--windup-documentation.netlify.app/docs/getting-started-guide/master/index.html#about-the-mta-operator_getting-started-guide
https://deploy-preview-550--windup-documentation.netlify.app/docs/getting-started-guide/master/index.html#about-vscode-extension_getting-started-guide
https://deploy-preview-550--windup-documentation.netlify.app/docs/getting-started-guide/master/index.html#intellij-about-plugin_getting-started-guide

Note that this PR includes only the changes in the Jira. It does not include the changes needed for rebranding MTA documentation.  
