### PR TITLE
Tackle-802: Proxy configuration for MTA 6.0

### DIFF
--- a/docs/topics/mta-web-proxy-config.adoc
+++ b/docs/topics/mta-web-proxy-config.adoc
@@ -1,0 +1,19 @@
+// Module included in the following assemblies:
+//
+// * docs/cli-guide/master.adoc
+
+:_content-type: PROCEDURE
+[id="mta-web-proxy-config_{context}"]
+= Configuring HTTP and HTTPS proxy settings
+
+You can configure HTTP and HTTPS proxy settings with this management module.
+
+.Procedure
+
+. In the *Administrator* view, click *Proxy*.
+. Toggle *HTTP proxy* or *HTTPS proxy* to enable the proxy connection.
+. Enter the following information:
+* Proxy host
+* Proxy port
+. Optional: Toggle *HTTP proxy credentials* or *HTTPS proxy credentials* to enable authentication.
+. Click *Insert*.

--- a/docs/web-console-guide/master.adoc
+++ b/docs/web-console-guide/master.adoc
@@ -33,9 +33,8 @@ include::topics/about-the-user-interface.adoc[leveloffset=+2]
 // Intro about the three sets of activities
 include::topics/mta-web-administrator-view.adoc[leveloffset=+1]
 
-// include::topics/ about credentials [all topic names that do not end in .adoc are just made up names; the real module names will need to follow our documentation rules]
+// include::topics/ Credentials
 // include::topics/ about repositories
-// include::topics/ about proxy
 
 // === Developer view
 
@@ -129,12 +128,20 @@ include::topics/mta-web-administrator-view.adoc[leveloffset=+1]
 
 // include::topics/
 
-// ===Configuring Maven repositories
-include::topics/mta-web-config-maven-rep.adoc[leveloffset=+3]
-
-// === Configuring HTTP and HTTPS proxy settings
+// ==== Configuring Maven repositories
 
 // include::topics/
+
+// ===== Configuring a Maven repository
+
+// include::topics/
+
+// ===== Managing repository size
+
+// include::topics/
+
+// === Configuring HTTP and HTTPS proxy settings
+include::topics/mta-web-proxy-config.adoc[leveloffset=2]
 
 // === Seeding instances
 


### PR DESCRIPTION
MTA 6.0

Resolves: https://issues.redhat.com/browse/TACKLE-802

Preview: https://deploy-preview-562--windup-documentation.netlify.app/docs/web-console-guide/master/index.html#configuring-http-and-https-proxy-settings