### PR TITLE
Rebuilds MTA User interface guide; fixes installation instructions

### DIFF
--- a/docs/topics/about-the-mta-operator.adoc
+++ b/docs/topics/about-the-mta-operator.adoc
@@ -6,6 +6,6 @@
 [id="about-the-mta-operator_{context}"]
 = About the {ProductShortName} Operator
 
-You can install the web console on OpenShift Container Platform versions 4.9-4.11 with the Migration Toolkit for Applications Operator.
+You can install the (WebName) on OpenShift Container Platform versions 4.9-4.11 with the Migration Toolkit for Applications Operator.
 
 // For installation instructions, see link:{ProductDocWebConsoleGuideURL}/index#installing_the_web_console[Installing the web console].

--- a/docs/topics/about-the-user-interface.adoc
+++ b/docs/topics/about-the-user-interface.adoc
@@ -6,6 +6,6 @@
 [id="about-the-user-interface_{context}"]
 = About the {WebName}
 
-The {WebName} for the {ProductName} allows a team of users to assess and analayze applications for risks and suitability for migration to hybrid cloud environments on Red Hat OpenShift.
+The {WebName} for the {ProductName} lets you assess and analayze applications for risks and suitability for migration to hybrid cloud environments on Red Hat OpenShift.
 
-Use the {WebName} to assess and analyze your applications to get insights about potential pitfalls in the adoption process, at both the portfolio and application levels as you inventory, assess, analyze, and manage applications for faster migration to OpenShift.
+The {WebName} lets you assess and analyze your applications to get insights about potential pitfalls in the adoption process, at both the portfolio and application levels as you inventory, assess, analyze, and manage applications for faster migration to OpenShift.

--- a/docs/topics/mta-6-installing-web-console-on-openshift.adoc
+++ b/docs/topics/mta-6-installing-web-console-on-openshift.adoc
@@ -13,7 +13,7 @@ The {ProductShortName} Operator is a structural layer that manages resources dep
 
 == Persistent volume requirements
 
-The {ProductShortName} Operator requires a total of 5 persistent volumes (PVs) used by different components to successfully deploy, 3 RWO volumes and 2 RWX volumes that are requested via PVCs. These PVS are described in the table below:
+The {ProductShortName} Operator requires a total of 5 persistent volumes (PVs) used by different components to successfully deploy, 3 RWO volumes and 2 RWX volumes that are requested via PVCs. The 5 PVs are described in the table below:
 
 .Required persistent volumes
 [cols="25%,25%,25%,25%", options="header"]
@@ -71,3 +71,7 @@ You can install the {ProductName} ({ProductShortName}) and the {WebName} on Open
 . Review options - the default selections should be OK, but be sure to validate the system requirements for storage, memory, and cores - and then click *Create*.
 . In *Administrator* view, click *Workloads -> Pods* to verify that the MTA pods are running.
 . Access the {WebName} from your browser by using the route exposed by the `{LC_PSN}-web-console` application within OpenShift.
+. Use the following credentials to log in:
+** *User name*: admin
+** *Password*: Passw0rd!
+. When prompted, create a new password.

--- a/docs/topics/mta-about-console-guide.adoc
+++ b/docs/topics/mta-about-console-guide.adoc
@@ -10,5 +10,5 @@ This guide is for architects, engineers, consultants, and others who want to use
 
 [NOTE]
 ====
-The migration solution provided in the Migration Toolkit for Applications 5,_x_ releases (migration and modernization of Java applications) is available with Migration Toolkit for Runtimes 1.0.
+The migration solution that was provided in the Migration Toolkit for Applications 5._x_ releases (migration and modernization of Java applications) is now available with Migration Toolkit for Runtimes 1.0.
 ====

--- a/docs/topics/mta-about-the-intro-to-mta-guide.adoc
+++ b/docs/topics/mta-about-the-intro-to-mta-guide.adoc
@@ -7,3 +7,8 @@
 = About the {IntroToMTABookName}
 
 This guide is for architects, engineers, consultants, and others who want to use the {ProductName} ({ProductShortName}) to accelerate large-scale application modernization efforts across hybrid cloud environments on Red Hat OpenShift. It provides an overview of the {ProductName} and how to get started using the tools to plan and run your migration.
+
+[NOTE]
+====
+The migration solution for Java applications that was provided in the Migration Toolkit for Applications 5.x releases (migration and modernization of Java applications) is now available with Migration Toolkit for Runtimes 1.0.
+====

--- a/docs/topics/mta-web-application-attributes.adoc
+++ b/docs/topics/mta-web-application-attributes.adoc
@@ -4,7 +4,7 @@
 
 :_content-type: CONCEPT
 [id="mta-web-application-attributes_{context}"]
-= Appplication attributes
+= Application attributes
 
 You can add applications to the {ProductName} ({ProductShortName}) {WebName} manually or by importing a list of applications.
 

--- a/docs/topics/mta-web-assessing-apps.adoc
+++ b/docs/topics/mta-web-assessing-apps.adoc
@@ -13,7 +13,7 @@ You can use the {ProductName} ({ProductShortName}) {WebName} to determine the ri
 . In *Development* view, click *Application inventory*.
 +
 // ![](/Tackle2/AppAssessAnalyze/AnalysisSelect.png)
-. Select the application you want to access.
+. Select the application you want to assess.
 +
 [NOTE]
 ====

--- a/docs/topics/mta-web-reviewing-an-analysis-report.adoc
+++ b/docs/topics/mta-web-reviewing-an-analysis-report.adoc
@@ -6,7 +6,7 @@
 [id="mta-web-reviewing-an-analysis-report_{context}"]
 = Reviewing an analysis report
 
-A {ProductShortName} analysis report contains a variety of sections including a listing of the technologies used by the application, the dependencies of the application, and the lines of code that must be changed in order to successfully migrate or modernize the application.
+An {ProductShortName} analysis report contains a variety of sections, including a listing of the technologies used by the application, the dependencies of the application, and the lines of code that must be changed to successfully migrate or modernize the application.
 
 For more information on the contents of a {ProductShortName} analysis report, see the link:{ProductDocUserGuideURL}[_{UserCLIBookName}_].
 

--- a/docs/topics/mta-what-is-the-toolkit.adoc
+++ b/docs/topics/mta-what-is-the-toolkit.adoc
@@ -19,7 +19,7 @@
 
 {ProductShortName} uses an extensive questionaire as the the basis for assessing your applications, enabling you to estimate the difficulty, time, and other resources needed to prepare an application for containerization. You can use the results of an assessment as the basis for discussions between stakeholders to determine which applications are good candidates for containerization, which require significant work first, and which are not suitable for containerization.
 
-{ProductShortName} analyzes applications with by applying one or more rulesets to each application considered to determine which specific lines of that application must be modified before it can be modernized.
+{ProductShortName} analyzes applications by applying one or more rulesets to each application considered to determine which specific lines of that application must be modified before it can be modernized.
 
 {ProductShortName} examines application artifacts, including project source directories and application archives, and then produces an HTML report highlighting areas needing changes. {ProductShortName} supports many migration paths including the following:
 

--- a/docs/web-console-guide/master.adoc
+++ b/docs/web-console-guide/master.adoc
@@ -1,55 +1,120 @@
 :toc:
 :toclevels: 4
 :numbered:
-:mtr:
+:mta:
 include::topics/templates/document-attributes.adoc[]
 
 :imagesdir: topics/images
-:context: web-console-guide
-:web-console-guide:
 :_content-type: ASSEMBLY
 = {WebConsoleBookName}
 
 //Inclusive language statement
 include::topics/making-open-source-more-inclusive.adoc[]
 
+[id="mta-6-ui-guide-introduction"]
 == Introduction
 
 // About the {WebConsoleBookName}
-include::topics/about-console-guide.adoc[leveloffset=+2]
+include::topics/mta-about-console-guide.adoc[leveloffset=+2]
 
 // About {ProductName}
-include::topics/what-is-the-toolkit.adoc[leveloffset=+2]
+include::topics/mta-what-is-the-toolkit.adoc[leveloffset=+2]
 
 // About the {WebName}
-include::topics/about-the-web-console.adoc[leveloffset=+2]
+include::topics/about-the-user-interface.adoc[leveloffset=+2]]
 
-== Installing the {WebName}
+[id=mta-6-ui-interface-views]
+== User interface views
 
-You can install the {WebName} on Linux, Windows, macOS, or {ocp-full}.
+The {ProductName} ({ProductShortName}) {WebName} has two uviews:
 
-// Installing on Linux, Windows, macOS
-include::topics/installing-web-console-or-cli-tool.adoc[leveloffset=+2]
-// Installing on OCP
-include::topics/installing-web-console-on-openshift.adoc[leveloffset=+2]
+* Administrator view
+* Developer view
 
-==== Troubleshooting a {WebName} installation on OpenShift
+In *Administrator* view, you configure the instance environment, working with credentials, repositories, and HTTP and HTTPS proxy definitions.
 
-This section describes how to troubleshoot a {WebName} installation on OpenShift Container Platform.
+In *Developer* view, you perform application assessments and analyses, review reports, and add applications for assessment and analysis.
 
-//Downloading logs with OCP console
-include::topics/proc_web-downloading-logs-console.adoc[leveloffset=+4]
+// == Administrator view
+// include::topics/mta-web-administrator-view.adoc[leveloffset=+1]
 
-//Downloading logs with the CLI
-include::topics/proc_web-downloading-logs-cli.adoc[leveloffset=+4]
-include::topics/web-openshift-no-route-to-host-error.adoc[leveloffset=+4]
-include::topics/web-openshift-insufficient-resources.adoc[leveloffset=+4]
+// Installation
+include::topics/mta-6-installing-web-console-on-openshift.adoc[leveloffset=+1]
 
-// Reporting issues
+[id="configuring-the-instance-environment"]
+== Configuring the instance environment
 
-===== Reporting issues
+You can configure the following in *Administrator* view:
 
-{ProductShortName} uses Jira as its issue tracking system. If you encounter an issue executing {ProductShortName}, submit a link:{JiraWindupURL}[Jira issue].
+* Credentials
+* Repositories
+* HTTP and HTTPS proxy settings
+
+[id="configuring-credentials"]
+=== Configuring credentials
+
+You can configure the following types of credentials in *Administrator* view:
+
+* Source control
+* Maven
+* Proxy
+
+include::topics/mta-web-config-source-control-credentials.adoc[leveloffset=+3]
+include::topics/mta-web-config-maven-credentials.adoc[leveloffset=+3]
+include::topics/mta-web-config-proxy-credentials.adoc[leveloffset=+3]
+
+[id="configuring-repositories"]
+=== Configuring repositories
+
+You can configure the following types of repositories in *Administrator* view:
+
+* Git
+* Subversion
+* Maven
+
+include::topics/mta-web-config-git-repos.adoc[leveloffset=+3]
+include::topics/mta-web-config-subversion-repos.adoc[leveloffset=+3]
+
+[id="configuring-maven-repositories"]
+==== Configuring a Maven repository and reducing its size
+
+You can use the (ProductShortName) {WebName} to both configure a Maven repository and to reduce its size.
+
+include::topics/mta-web-config-maven-repo.adoc[leveloffset=+4]
+include::topics/mta-web-config-maven-repo-size.adoc[leveloffset=+4]
+
+// === Configuring HTTP and HTTPS proxy settings
+include::topics/mta-web-proxy-config.adoc[leveloffset=2]
+
+[id="assessing-and-analyzing-applications"]
+== Assessing and analyzing applications
+You can use the {ProductName} ({ProductShortName}) {WebName} to both assess and to analyze applications.
+
+Assessing applications refers to estimating the risks and costs involved in preparing applications for containerization, including time, personnel, and other factors. The results of an assessment can be used as the basis for discussions between stakeholders to determine which applications are good candidates for containerization, which require significant work, and which are not suitable for containerization.
+
+Analyzing applications refers to using rules to determine which specific lines in an application must be modified before the application can be migrated or modernized.
+
+include::topics/mta-web-assessing-apps.adoc[leveloffset=+2]
+include::topics/mta-web-applying-assessments-to-other-apps.adoc[leveloffset=+2]
+include::topics/mta-web-configuring-and-running-an-application-analysis.adoc[leveloffset=+2]
+include::topics/mta-web-reviewing-an-analysis-report.adoc[leveloffset=+2]
+
+[id=working-with-applications-in-the-ui]
+== Working with Applications
+
+You can use the {ProductName} ({ProductShortName}) {WebName} to do the following:
+
+* Add applications
+* Assign application credentials
+* Import a list of applications
+* Download a CSV template for importing application lists
+
+include::topics/mta-web-application-attributes.adoc[leveloffset=+2]
+include::topics/mta-web-adding-applications.adoc[leveloffset=+2]
+include::topics/mta-web-assigning-application-credentials.adoc[leveloffset=+2]
+include::topics/mta-web-importing-an-app-list.adoc[leveloffset=+2]
+include::topics/mta-web-downloading-app-list-template.adoc[leveloffset=+2]
+
 
 == Using the {WebName} to analyze applications
 


### PR DESCRIPTION
Preview of installation instructions: https://deploy-preview-616--windup-documentation.netlify.app/docs/web-console-guide/master/index.html#installing-the-migration-toolkit-for-applications-operator-and-the-user-interface

Preview of entire UI guide: https://deploy-preview-616--windup-documentation.netlify.app/docs/web-console-guide/master/index.html  [The phrase "Web Console Guide" at the top of the preview appears only in the Deploy Preview.]

