### PR TITLE
TACKLE-875: Correct link for 'Reviewing the reports"

### DIFF
--- a/docs/topics/create-first-xml-rule.adoc
+++ b/docs/topics/create-first-xml-rule.adoc
@@ -225,7 +225,7 @@ Report created: /home/<USER_NAME>/migration-rules/reports/index.html
 [discrete]
 == Reviewing the reports
 
-Review the report to be sure that it provides the expected results. For a more detailed walkthrough of {ProductShortName} reports, see the link:{ProductDocUserGuideURL}#review_reports[Review the reports] section of the {ProductShortName} _{UserCLIBookName}_.
+Review the report to be sure that it provides the expected results. For a more detailed walkthrough of {ProductShortName} reports, see the link:{ProductDocUserGuideURL}#review_reports_cli-guide[Reviewing the reports] section of the {ProductShortName} _{UserCLIBookName}_.
 
 . Open `/home/<USER_NAME>/migration-rules/reports/index.html` in a web browser.
 . Verify that the rule ran successfully.

--- a/docs/topics/create-first-xml-rule.adoc
+++ b/docs/topics/create-first-xml-rule.adoc
@@ -225,7 +225,7 @@ Report created: /home/<USER_NAME>/migration-rules/reports/index.html
 [discrete]
 == Reviewing the reports
 
-Review the report to be sure that it provides the expected results. For a more detailed walkthrough of {ProductShortName} reports, see the link:{ProductDocUserGuideURL}#review_reports_cli-guide[Reviewing the reports] section of the {ProductShortName} _{UserCLIBookName}_.
+Review the report to be sure that it provides the expected results. For a more detailed walkthrough of {ProductShortName} reports, see the link:{ProductDocUserGuideURL}#review-reports_cli-guide[Reviewing the reports] section of the {ProductShortName} _{UserCLIBookName}_.
 
 . Open `/home/<USER_NAME>/migration-rules/reports/index.html` in a web browser.
 . Verify that the rule ran successfully.

--- a/docs/topics/maven-access-reports.adoc
+++ b/docs/topics/maven-access-reports.adoc
@@ -25,4 +25,4 @@ The output directory contains the following files and subdirectories:
 ├── stats/              // Performance statistics
 ----
 
-See the link:{ProductDocUserGuideURL}#review_reports[Review the reports] section of the {ProductShortName} _{UserCLIBookName}_ for information on the {ProductShortName} reports and how to use them to assess your migration or modernization effort.
+See the link:{ProductDocUserGuideURL}#review_reports_cli-guide[Reviewing the reports] section of the {ProductShortName} _{UserCLIBookName}_ for information on the {ProductShortName} reports and how to use them to assess your migration or modernization effort.

--- a/docs/topics/maven-access-reports.adoc
+++ b/docs/topics/maven-access-reports.adoc
@@ -25,4 +25,4 @@ The output directory contains the following files and subdirectories:
 ├── stats/              // Performance statistics
 ----
 
-See the link:{ProductDocUserGuideURL}#review_reports_cli-guide[Reviewing the reports] section of the {ProductShortName} _{UserCLIBookName}_ for information on the {ProductShortName} reports and how to use them to assess your migration or modernization effort.
+See the link:{ProductDocUserGuideURL}#review-reports_cli-guide[Reviewing the reports] section of the {ProductShortName} _{UserCLIBookName}_ for information on the {ProductShortName} reports and how to use them to assess your migration or modernization effort.

--- a/docs/topics/mta-web-reviewing-an-analysis-report.adoc
+++ b/docs/topics/mta-web-reviewing-an-analysis-report.adoc
@@ -8,7 +8,7 @@
 
 An {ProductShortName} analysis report contains a variety of sections, including a listing of the technologies used by the application, the dependencies of the application, and the lines of code that must be changed to successfully migrate or modernize the application.
 
-For more information on the contents of a {ProductShortName} analysis report, see the link:{ProductDocUserGuideURL}#review_reports_cli-guide[Reviewing the reports]
+For more information on the contents of a {ProductShortName} analysis report, see the link:{ProductDocUserGuideURL}#review-reports_cli-guide[Reviewing the reports]
 
 .Procedure
 
@@ -17,5 +17,3 @@ For more information on the contents of a {ProductShortName} analysis report, se
 3. Click *Report*.
 4. Click the dependencies or source links.
 5. Click the tabs to review the report.
-
-test

--- a/docs/topics/mta-web-reviewing-an-analysis-report.adoc
+++ b/docs/topics/mta-web-reviewing-an-analysis-report.adoc
@@ -8,7 +8,7 @@
 
 An {ProductShortName} analysis report contains a variety of sections, including a listing of the technologies used by the application, the dependencies of the application, and the lines of code that must be changed to successfully migrate or modernize the application.
 
-For more information on the contents of a {ProductShortName} analysis report, see the link:{ProductDocUserGuideURL}[_{UserCLIBookName}_].
+For more information on the contents of a {ProductShortName} analysis report, see the link:{ProductDocUserGuideURL}#review_reports_cli-guide[Reviewing the reports]
 
 .Procedure
 

--- a/docs/topics/mta-web-reviewing-an-analysis-report.adoc
+++ b/docs/topics/mta-web-reviewing-an-analysis-report.adoc
@@ -17,3 +17,5 @@ For more information on the contents of a {ProductShortName} analysis report, se
 3. Click *Report*.
 4. Click the dependencies or source links.
 5. Click the tabs to review the report.
+
+test

--- a/docs/topics/rules-guide-intro.adoc
+++ b/docs/topics/rules-guide-intro.adoc
@@ -8,6 +8,6 @@
 
 This guide is for engineers, consultants, and others who want to create custom XML-based rules for {ProductName} ({ProductShortName}) tools.
 
-For more information, see the link:{ProductDocIntroTo{ProductShortName}GuideURL}[_{IntroToMTABookName}_] for an overview and the link:{ProductDocUserGuideURL}[_{UserCLIBookName}_] for details.
+For more information, see the link:{ProductDocIntroToMTAGuideURL}[_{IntroToMTABookName}_] for an overview and the link:{ProductDocUserGuideURL}[_{UserCLIBookName}_] for details.
 
 To contribute to the {ProductShortName} source code base or provide Java-based rule add-ons, see the link:{ProductDocCoreGuideURL}[_Core Development Guide_].

--- a/docs/topics/web-review-reports.adoc
+++ b/docs/topics/web-review-reports.adoc
@@ -8,7 +8,7 @@
 
 The {ProductShortName} {WebName} provides a set of detailed reports that can help you decide if you need to make any changes to your applications. You access these reports from the *Analysis results* screen.
 
-The reports are described in detail in link:{ProductDocUserGuideURL}#review_reports_cli-guide[Reviewing the reports] in the _{UserCLIBookName}_.
+The reports are described in detail in link:{ProductDocUserGuideURL}#review-reports_cli-guide[Reviewing the reports] in the _{UserCLIBookName}_.
 
 .Procedure
 . In the {WebName}, click *Analysis results*.

--- a/docs/topics/web-review-reports.adoc
+++ b/docs/topics/web-review-reports.adoc
@@ -8,7 +8,7 @@
 
 The {ProductShortName} {WebName} provides a set of detailed reports that can help you decide if you need to make any changes to your applications. You access these reports from the *Analysis results* screen.
 
-The reports are described in detail in link:{ProductDocUserGuideURL}/index#review_reports_cli-guide[{ProductShortName} reports] in the _{UserCLIBookName}_.
+The reports are described in detail in link:{ProductDocUserGuideURL}#review_reports_cli-guide[Reviewing the reports] in the _{UserCLIBookName}_.
 
 .Procedure
 . In the {WebName}, click *Analysis results*.


### PR DESCRIPTION
MTA 6.0/MTR 1.0

Resolves https://issues.redhat.com/browse/TACKLE-875 by fixing links to the "Reviewing the reports" section of the CLI guide (Previews 1-3) and fiixes incorrect link in the Rules Development Guide (preview 4) .  

Previews:
1. See "Reviewing the rules" in https://deploy-preview-622--windup-documentation.netlify.app/docs/rules-development-guide/master/index.html#create-first-xml-rule_rules-development-guide  [MTA] and https://deploy-preview-622--windup-documentation.netlify.app/docs/rules-development-guide-mtr/master/index.html#create-first-xml-rule_rules-development-guide-mtr [MTR]

2. See "Reviewing an analysis report"  in https://deploy-preview-622--windup-documentation.netlify.app/docs/web-console-guide/master/index.html#mta-web-reviewing-an-analysis-report_user-interface-guide [MTA] and "Reviewing reports" in https://deploy-preview-622--windup-documentation.netlify.app/docs/web-console-guide-mtr/master/index.html#web-review-reports_web-console-guide [MTR]

3. See "Accessing the report" in https://deploy-preview-622--windup-documentation.netlify.app/docs/maven-guide/master/index.html#maven-access-reports_maven-guide [MTA] and https://deploy-preview-622--windup-documentation.netlify.app/docs/maven-guide-mtr/master/index.html#maven-access-reports_maven-guide [MTR]

4. See "Introduction to te Migration Toolkit for Aplications" in https://deploy-preview-622--windup-documentation.netlify.app/docs/rules-development-guide/master/index.html#rules-guide-intro_rules-development-guide.
