### PR TITLE
TACKLE-876: Fix links and other errors in the Rules Development guide

### DIFF
--- a/docs/topics/create-first-xml-rule.adoc
+++ b/docs/topics/create-first-xml-rule.adoc
@@ -41,9 +41,9 @@ This directory structure will also be used to hold the generated {ProductShortNa
     </class-loading>
 </jboss-web>
 ----
-
+[]
 [discrete]
-== Creating the rule
+Creating the rule
 
 {ProductShortName} XML-based rules use the following rule pattern:
 
@@ -191,7 +191,7 @@ The rule is now complete and should look like the following example.
      </rules>
 </ruleset>
 ----
-
+[]
 [discrete]
 == Installing the rule
 
@@ -203,7 +203,7 @@ Copy the `JBoss5-web-class-loading.windup.xml` file to the `<{ProductShortName}_
 ----
 $ cp /home/<USER_NAME>/migration-rules/rules/JBoss5-web-class-loading.windup.xml <{ProductShortName}_HOME>/rules/
 ----
-
+[]
 [discrete]
 == Testing the rule
 
@@ -221,7 +221,7 @@ You should see the following result.
 Report created: /home/<USER_NAME>/migration-rules/reports/index.html
               Access it at this URL: file:///home/<USER_NAME>/migration-rules/reports/index.html
 ----
-
+[]
 [discrete]
 == Reviewing the reports
 
@@ -247,4 +247,4 @@ You can see that the `<class-loading>` line is highlighted, and the hint from th
 image::test-rule-details.png[Rule match]
 +
 // TODO: Consider updating with test data/rule combo that won't match on any of the other existing rules.
-The top of the file lists the classifications for matching rules. You can use the link icon to view the details for that rule. Notice that in this example, the `jboss-web.xml` file matched on another rule (`JBoss web application descriptor (jboss-web.xml)`) that produced `1` story point. This, combined with the `1` story point from our custom rule, brings the total story points for this file to `2`.
+The top of the file lists the classifications for matching rules. You can use the link icon to view the details for that rule. Notice that in this example, the `jboss-web.xml` file matched on another rule (`JBoss web application descriptor (jboss-web.xml)`) that produced `1` story point. This story point, combined with the `1` story point from our custom rule, brings the total story points for this file to `2`.

--- a/docs/topics/review-existing-rules.adoc
+++ b/docs/topics/review-existing-rules.adoc
@@ -6,7 +6,7 @@
 [id="review-existing-rules_{context}"]
 = Reviewing existing {ProductShortName} XML rules
 
-{ProductShortName} XML-based rules are located on GitHub at the following location: link:https://github.com/windup/windup-rulesets/tree/master/rules-reviewed[https://github.com/windup/windup-rulesets/tree/master/rules-reviewed].
+{ProductShortName} XML-based rules are located on GitHub at the following location: link:https://github.com/windup/windup-rulesets/tree/master/rules/rules-reviewed[https://github.com/windup/windup-rulesets/tree/master/rules/rules-reviewed].
 
 You can fork and clone the {ProductShortName} XML rules on your local machine.
 

--- a/docs/topics/rules-testing-junit.adoc
+++ b/docs/topics/rules-testing-junit.adoc
@@ -47,5 +47,5 @@ image::junit-test.png[]
 image::junit-test-arguments.png[]
 
 . Click *Run* in the bottom right corner to begin the test.
-
-Once the execution completes the results will be available for analysis. If all tests passed, then the test rule is correctly formatted; otherwise, it is recommended to address each of the issues raised in the test failures.
++
+When the execution completes, the results are available for analysis. If all tests passed, then the test rule is correctly formatted. If all tests did not pass, it is recommended to address each of the issues raised in the test failures.


### PR DESCRIPTION
MTA 6.0/MTR 1.0

Resolves https://issues.redhat.com/browse/TACKLE-876 with a number of small fixes:

Jira items 1, 2, and 3 resolved in Jira.

Item 4: First link in https://deploy-preview-625--windup-documentation.netlify.app/docs/rules-development-guide/master/index.html#review-existing-rules_rules-development-guide

Item 5: Last paragraph of https://deploy-preview-625--windup-documentation.netlify.app/docs/rules-development-guide/master/index.html#rules-testng-junit_rules-development-guide

Item 6: Last paragraph of https://deploy-preview-625--windup-documentation.netlify.app/docs/rules-development-guide/master/index.html#create-first-xml-rule_rules-development-guide

Item 7: Space beteween figures and titles in https://deploy-preview-625--windup-documentation.netlify.app/docs/rules-development-guide/master/index.html#create-first-xml-rule_rules-development-guide
