### PR TITLE
Removes MTR sections from MTA UI guide

### DIFF
--- a/docs/web-console-guide/master.adoc
+++ b/docs/web-console-guide/master.adoc
@@ -28,7 +28,7 @@ include::topics/about-the-user-interface.adoc[leveloffset=+2]]
 [id=mta-6-ui-interface-views]
 == User interface views
 
-The {ProductName} ({ProductShortName}) {WebName} has two uviews:
+The {ProductName} ({ProductShortName}) {WebName} has two views:
 
 * Administrator view
 * Developer view
@@ -80,7 +80,7 @@ include::topics/mta-web-config-subversion-repos.adoc[leveloffset=+3]
 [id="configuring-maven-repositories"]
 ==== Configuring a Maven repository and reducing its size
 
-You can use the (ProductShortName) {WebName} to both configure a Maven repository and to reduce its size.
+You can use the {ProductShortName} {WebName} to both configure a Maven repository and to reduce its size.
 
 include::topics/mta-web-config-maven-repo.adoc[leveloffset=+4]
 include::topics/mta-web-config-maven-repo-size.adoc[leveloffset=+4]
@@ -116,41 +116,6 @@ include::topics/mta-web-adding-applications.adoc[leveloffset=+2]
 include::topics/mta-web-assigning-application-credentials.adoc[leveloffset=+2]
 include::topics/mta-web-importing-an-app-list.adoc[leveloffset=+2]
 include::topics/mta-web-downloading-app-list-template.adoc[leveloffset=+2]
-
-
-== Using the {WebName} to analyze applications
-
-You can create a project in the web console to analyze your applications.
-
-Each project groups the applications for a specific analysis, which you can configure with custom rules and labels.
-
-The analysis process generates reports that describe the readiness of your applications for migration or modernization.
-
-// Creating a project
-include::topics/web-create-project.adoc[leveloffset=+2]
-
-// Running a saved analysis
-include::topics/web-running-saved-analysis.adoc[leveloffset=+2]
-
-// Viewing the Results of an Analysis
-include::topics/web-view-results.adoc[leveloffset=+2]
-
-// Review the Reports
-include::topics/web-review-reports.adoc[leveloffset=+2]
-
-//Reconfigure Analysis
-include::topics/web-updating-an-analysis.adoc[leveloffset=+2]
-
-// Using Custom Rules
-include::topics/web-adding-global-custom-rules.adoc[leveloffset=+2]
-
-// Using Custom Labels
-include::topics/web-adding-global-custom-labels.adoc[leveloffset=+2]
-
-// Require Authentication for {ProductWebName}
-include::topics/configuring-web-console-authentication-for-linux-windows-macos.adoc[leveloffset=+1]
-
-// TODO: eventually add steps for reverting back to no auth required
 
 
 // **********************************


### PR DESCRIPTION
MTA 6.0

Resolves https://issues.redhat.com/browse/TACKLE-880 

Previews: 
1. https://deploy-preview-626--windup-documentation.netlify.app/docs/web-console-guide/master/index.html (You can see that chapters 7 and 8 are gone).
2. https://deploy-preview-626--windup-documentation.netlify.app/docs/web-console-guide/master/index.html#mta-6-ui-interface-views ["u" removed from "uviews."]
3. https://deploy-preview-626--windup-documentation.netlify.app/docs/web-console-guide/master/index.html#configuring-maven-repositories ["(ProductShortName)" no longer appears.] 