### PR TITLE
Fixes link in "About the Migration Toolkit for Appplications" section

### DIFF
--- a/docs/eclipse-code-ready-studio-guide/master.adoc
+++ b/docs/eclipse-code-ready-studio-guide/master.adoc
@@ -20,7 +20,7 @@ include::topics/making-open-source-more-inclusive.adoc[]
 == Introduction
 
 include::topics/about-ide-addons.adoc[leveloffset=+2]
-include::topics/what-is-the-toolkit.adoc[leveloffset=+2]
+include::topics/mta-what-is-the-toolkit.adoc[leveloffset=+2]
 
 [id="installing-plugin_{context}"]
 == Installing the {PluginName}

--- a/docs/vs-code-extension-guide/master.adoc
+++ b/docs/vs-code-extension-guide/master.adoc
@@ -21,7 +21,7 @@ include::topics/making-open-source-more-inclusive.adoc[]
 include::topics/about-ide-addons.adoc[leveloffset=+2]
 
 // About {ProductName}
-include::topics/what-is-the-toolkit.adoc[leveloffset=+2]
+include::topics/mta-what-is-the-toolkit.adoc[leveloffset=+2]
 
 // Install the extension
 include::topics/installing-vs-code-extension.adoc[leveloffset=+1]


### PR DESCRIPTION
MTA 6.0

Resolves https://issues.redhat.com/browse/TACKLE-878 by fixing a link in the "About the Migration Toolkit for Applications" section of the Eclipse guide (same problem fixed throughout repo).

Preview: https://deploy-preview-627--windup-documentation.netlify.app/docs/eclipse-code-ready-studio-guide/master/index.html#mta-what-is-the-toolkit_eclipse-code-ready-studio-guide