### PR TITLE
Spacing between code blocks and discrete headings 

### DIFF
--- a/docs/topics/cli-run.adoc
+++ b/docs/topics/cli-run.adoc
@@ -43,6 +43,7 @@ $ <{ProductShortName}_HOME>/bin/windup-cli \
     --output /path/to/report-output/ --source eap:5 --target eap:7 \
     --packages com.acme org.apache
 ----
+[]
 
 [discrete]
 === Running {ProductShortName} on source code
@@ -54,6 +55,7 @@ The following command analyzes the `org.jboss.seam` packages of the link:https:/
 $ <{ProductShortName}_HOME>/bin/windup-cli --sourceMode --input /path/to/seam-booking-5.2/ \
     --output /path/to/report-output/ --target eap:6 --packages org.jboss.seam
 ----
+[]
 
 [discrete]
 === Running cloud-readiness rules
@@ -66,6 +68,7 @@ $ <{ProductShortName}_HOME>/bin/windup-cli --input /path/to/jee-example-app-1.0.
     --output /path/to/report-output/ \
     --target eap:7 --target cloud-readiness --packages com.acme org.apache
 ----
+[]
 
 [discrete]
 === Overriding {ProductShortName} properties


### PR DESCRIPTION
MTA 6.0/MTR 1.0

Adds space between code blocks and discrete headings in the CLI guide.