### PR TITLE
Spacing again

### DIFF
--- a/docs/topics/cli-run.adoc
+++ b/docs/topics/cli-run.adoc
@@ -56,7 +56,6 @@ $ <{ProductShortName}_HOME>/bin/windup-cli --sourceMode --input /path/to/seam-bo
     --output /path/to/report-output/ --target eap:6 --packages org.jboss.seam
 ----
 []
-
 [discrete]
 === Running cloud-readiness rules
 


### PR DESCRIPTION
MTA 6.0
Increases spacing between code blocks and discrete headings in section 2.2 of the  CLI guide 