### PR TITLE
z-stream version numbers in repo

### DIFF
--- a/docs/topics/maven-multi-module.adoc
+++ b/docs/topics/maven-multi-module.adoc
@@ -19,7 +19,7 @@ To run the {MavenName} in a project with multiple modules perform the following 
 <plugin>
     <groupId>org.jboss.windup.plugin</groupId>
     <artifactId>mtr-maven-plugin</artifactId>
-    <version>1.0.0.GA-redhat-00001</version>
+    <version>1.0.1.GA-redhat-00003</version>
     <inherited>false</inherited>
     <executions>
         <execution>

--- a/docs/topics/maven-run.adoc
+++ b/docs/topics/maven-run.adoc
@@ -21,7 +21,7 @@ include::snippet_jdk-hardware-mac-prerequisites.adoc[]
 <plugin>
     <groupId>org.jboss.windup.plugin</groupId>
     <artifactId>mtr-maven-plugin</artifactId>
-    <version>1.0.0.GA-redhat-00001</version>
+    <version>1.0.1.GA-redhat-00003</version>
     <executions>
         <execution>
             <id>run-windup</id>

--- a/docs/topics/templates/document-attributes.adoc
+++ b/docs/topics/templates/document-attributes.adoc
@@ -16,17 +16,16 @@ ifdef::mta[]
 :DocInfoProductNumber: 6.0
 :ProductShortName: MTA
 :LC_PSN: mta
+:DocInfoProductNameURL: migration_toolkit_for_applications
 :WebName: User Interface
 :WebNameTitle: User Interface
 :WebNameURL: user_interface_guide
-:LC_PSN: mta
-:DocInfoProductNameURL: migration_toolkit_for_applications
 :WebConsoleBookName: {WebNameTitle} Guide
 :ProductVersion: 6.0.0
+:PluginName: MTA plugin
 :ProductDistributionVersion: 6.0.0.GA-redhat-00002
 :ProductDistribution: mta-6.0.0.GA-offline.zip
 :DevDownloadPageURL: https://developers.redhat.com/products/mta/download
-:PluginName: MTA plugin
 :IDEPluginFilename: migrationtoolkit-mta-eclipse-plugin-repository
 :JiraWindupURL: https://issues.redhat.com/projects/TACKLE
 :CodeReadyStudioDownloadPageURL: http://download.jboss.org/jbosstools/photon/stable/updates/mta/
@@ -43,17 +42,15 @@ ifdef::mtr[]
 :WebNameTitle: Web Console
 :WebNameURL: web_console_guide
 :WebConsoleBookName: {WebNameTitle} Guide
-:ProductVersion: 1.0.0.GA-redhat-00001
+:ProductVersion: 1.0.1
 :PluginName: MTR plugin
-:ProductDistributionVersion: 1.0.0.GA-redhat-00001
-:ProductDistribution: mtr-1.0.0.GA-offline.zip
-:ProductVersion: 1.0.0
+:ProductDistributionVersion: 1.0.1.GA-redhat-00003
+:ProductDistribution: mtr-1.0.1.GA-offline
 :DevDownloadPageURL: https://developers.redhat.com/products/mtr/download
+:IDEPluginFilename: migrationtoolkit-mtr-eclipse-plugin-repository
 :JiraWindupURL: https://issues.redhat.com/projects/WINDUP
 :CodeReadyStudioDownloadPageURL: http://download.jboss.org/jbosstools/photon/stable/updates/mtr/
-:IDEPluginFilename: migrationtoolkit-mtr-eclipse-plugin-repository
 endif::[]
-
 
 // *******************
 // * Component names *


### PR DESCRIPTION
MTR 1.0.1

Resolves https://issues.redhat.com/browse/WINDUP-3622 by updating the product version number in MTR documentation set to 1.0.1 where needed.

Previews:
1. https://deploy-preview-648--windup-documentation.netlify.app/docs/cli-guide-mtr/master/index.html#tech-tags_cli-guide  Correct version number: 1.0.1

2. https://deploy-preview-648--windup-documentation.netlify.app/docs/intellij-idea-plugin-guide-mtr/master/index.html#intellij-idea-plugin-run-configuration_idea-plugin-guide step 4: cli example -- For example: $HOME/mtr-cli-1.0.1.GA-redhat-00003/bin/windup-cli

3. https://deploy-preview-648--windup-documentation.netlify.app/docs/vs-code-extension-guide-mtr/master/index.html#vs-code-extension-run-configuration_vsc-extension-guide-mtr step 3: cli example -- For example: $HOME/mtr-cli-1.0.1.GA-redhat-00003/bin/windup-cli

4. https://deploy-preview-648--windup-documentation.netlify.app/docs/maven-guide-mtr/master/index.html#maven-run_maven-guide XML file in step 1 contains the correct version tags:   <version>1.0.1.GA-redhat-00003</version>

5. https://deploy-preview-648--windup-documentation.netlify.app/docs/maven-guide-mtr/master/index.html#maven-multi-module_maven-guide  XML file in step 1 contains the correct version tags:   <version>1.0.1.GA-redhat-00003</version>

6. https://deploy-preview-648--windup-documentation.netlify.app/docs/rules-development-guide-mtr/master/index.html#about-home-var_rules-development-guide-mtr The sentence "The installation directory is the mtr-1.0.1.GA-offline directory where you extracted the MTR .zip file. " was changed as requested. 