### PR TITLE
Release notes for MTA 6.0.1 including RWX parameter

### DIFF
--- a/docs/release-notes/master-docinfo.xml
+++ b/docs/release-notes/master-docinfo.xml
@@ -7,7 +7,7 @@
         {ProductName} {DocInfoProductNumber} accelerates large-scale application modernization efforts across hybrid cloud environments on Red Hat OpenShift. This solution provides insight throughout the adoption process, at both the portfolio and application levels: inventory, assess, analyze, and manage applications for faster migration to OpenShift via the user interface.
     </para>
 	<para>
-		This document describes new features, known issues, and resolved issues for the {DocInfoProductName}, version {ProductVersion}.
+		This document describes new features and improvements, known issues, and resolved issues for the {DocInfoProductName}, versions 6.0.0 and 6.0.1.
 	</para>
 </abstract>
 <authorgroup>

--- a/docs/release-notes/master.adoc
+++ b/docs/release-notes/master.adoc
@@ -13,10 +13,46 @@ include::topics/templates/document-attributes.adoc[]
 //Inclusive language statement
 include::topics/making-open-source-more-inclusive.adoc[]
 
-include::topics/mta-rn-new-features.adoc[leveloffset=+1]
+[id="release-notes-introduction"]
+== Introduction
+{ProductName} {DocInfoProductNumber} accelerates large-scale application modernization efforts across hybrid cloud environments on Red Hat OpenShift. This solution provides insight throughout the adoption process, at both the portfolio and application levels: inventory, assess, analyze, and manage applications for faster migration to OpenShift via the user interface.
 
-include::topics/mta-rn-known-issues.adoc[leveloffset=+1]
+These release notes cover all _z_-stream releases of {ProductShortName} 6.0 with the most recent release listed first.
 
-include::topics/mta-rn-resolved-issues.adoc[leveloffset=+1]
+[id="mta-6-0-1"]
+== {ProductShortName} 6.0.1
+
+include::topics/mta-rn-new-features-1.adoc[leveloffset=+2]
+
+You can set this parameter after you upgrade to {ProductVersion}.
+
+include::topics/mta-rn-upgrade-ui.adoc[leveloffset=+3]
+
+include::topics/mta-rn-upgrade-cli.adoc[leveloffset=+3]
+
+include::topics/mta-rn-known-issues-1.adoc[leveloffset=+2]
+
+include::topics/mta-rn-resolved-issues-1.adoc[leveloffset=+2]
+
+== {ProductShortName} 6.0.0
+include::topics/mta-rn-new-features.adoc[leveloffset=+2]
+
+include::topics/mta-rn-known-issues.adoc[leveloffset=+2]
+
+include::topics/mta-rn-resolved-issues.adoc[leveloffset=+2]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 :!release-notes:

--- a/docs/release-notes/master.adoc
+++ b/docs/release-notes/master.adoc
@@ -24,7 +24,10 @@ These release notes cover all _z_-stream releases of {ProductShortName} 6.0 with
 
 include::topics/mta-rn-new-features-1.adoc[leveloffset=+2]
 
-You can set this parameter after you upgrade to {ProductVersion}.
+[NOTE]
+====
+If you upgrade from version 6.0.0 to version 6.0.1, you can set this parameter after the upgrade.
+====
 
 include::topics/mta-rn-upgrade-ui.adoc[leveloffset=+3]
 

--- a/docs/topics/mta-6-installing-web-console-on-openshift.adoc
+++ b/docs/topics/mta-6-installing-web-console-on-openshift.adoc
@@ -134,6 +134,20 @@ The most commonly used CR settings are listed in this table:
 |NA
 |Storage class requested for the Tackle RW0 volumes
 |====
++
+.Example YAML file
+[sample,YAML]
+----
+kind: Tackle
+apiVersion: tackle.konveyor.io/v1alpha1
+metadata:
+  name: mta
+  namespace: openshift-mta
+spec:
+  hub_bucket_volume_size: "25Gi"
+  maven_data_volume_size: "25Gi"
+  rwx_supported: "false"
+----
 
 . Edit the CR settings if needed, and then click *Create*.
 . In *Administrator* view, click *Workloads -> Pods* to verify that the MTA pods are running.

--- a/docs/topics/mta-rn-known-issues-1.adoc
+++ b/docs/topics/mta-rn-known-issues-1.adoc
@@ -1,0 +1,9 @@
+// Module included in the following assemblies:
+//
+// * docs/release_notes/master.adoc
+
+:_content-type: REFERENCE
+[id="rn-known-issues-1_{context}"]
+= Known issues
+
+At the time of release, there are no known issues in this release.

--- a/docs/topics/mta-rn-new-features-1.adoc
+++ b/docs/topics/mta-rn-new-features-1.adoc
@@ -1,0 +1,13 @@
+// Module included in the following assemblies:
+//
+// * docs/release_notes/master.adoc
+
+:_content-type: CONCEPT
+[id="mta-rn-new-features-1_{context}"]
+= New features and improvements
+
+This section describes the new features and improvements of the {ProductName} ({ProductShortName}) {ProductVersion}.
+
+.Support for non-administrators to run {ProductShortName}
+For security reasons, the RWX permission set of {ProductShortName} 6.0.0 was configured to allow only administrators to run {ProductShortName}. In Version {ProductVersion}  you can now allow non-administrators to use {ProductShortName} by setting the value of a new parameter, `rwx_supported`, to `false` in the {ocp-first} web console or the {ProductShortName} {WebName}.
+

--- a/docs/topics/mta-rn-new-features-1.adoc
+++ b/docs/topics/mta-rn-new-features-1.adoc
@@ -9,5 +9,5 @@
 This section describes the new features and improvements of the {ProductName} ({ProductShortName}) {ProductVersion}.
 
 .Support for non-administrators to run {ProductShortName}
-For security reasons, the RWX permission set of {ProductShortName} 6.0.0 was configured to allow only administrators to run {ProductShortName}. In Version {ProductVersion}  you can now allow non-administrators to use {ProductShortName} by setting the value of a new parameter, `rwx_supported`, to `false` in the {ocp-first} web console or the {ProductShortName} {WebName}.
+For security reasons, the RWX permission set of {ProductShortName} 6.0.0 was configured to allow only administrators to run {ProductShortName}. In Version {ProductVersion}  you can now allow non-administrators to use {ProductShortName} by setting the value of a new parameter, `rwx_supported`, to `false` in the the {ProductShortName} Operator or the {ocp-first}  console.
 

--- a/docs/topics/mta-rn-new-features.adoc
+++ b/docs/topics/mta-rn-new-features.adoc
@@ -3,10 +3,10 @@
 // * docs/release_notes/master.adoc
 
 :_content-type: CONCEPT
-[id="rn-new-features_{context}"]
-= New features
+[id="mta-rn-new-features_{context}"]
+= New features and improvements
 
-This section describes the new features of the {ProductName} ({ProductShortName}) {ProductVersion}.
+This section describes the new features and improvements of the {ProductName} ({ProductShortName}) 6.0.0.
 
 .Application inventory module
 New application portfolio driven UI that enables organizations to manage and classify their applications using an extensible tagging model.

--- a/docs/topics/mta-rn-resolved-issues-1.adoc
+++ b/docs/topics/mta-rn-resolved-issues-1.adoc
@@ -1,0 +1,9 @@
+// Module included in the following assemblies:
+//
+// * docs/release_notes-6.0/master.adoc
+
+:_content-type: REFERENCE
+[id="mta-rn-resolved-issues-1_{context}"]
+= Resolved issues
+
+At the time of the release, there are no resolved issues for this release.

--- a/docs/topics/mta-rn-upgrade-cli.adoc
+++ b/docs/topics/mta-rn-upgrade-cli.adoc
@@ -4,13 +4,13 @@
 
 :_content-type: PROCEDURE
 [id="mta-rn-upgrade-cli_{context}"]
-= Setting the parameter in the {ocp-short} web console after upgrading to version {ProductVersion}
+= Setting the parameter in the {ocp-short} console after upgrading to version {ProductVersion}
 
-You can set the value of `rwx_supported` in the {ocp-short} web console after you upgrade to {ProductShortName} {ProductVersion}
+You can set the value of `rwx_supported` in the {ocp-short} console after you upgrade to {ProductShortName} {ProductVersion}.
 
 .Procedure
 
-. After you upgrade the {ProductShortName} Operator, log into your cluster in the {ocp-short} web console.
+. After you upgrade the {ProductShortName} Operator, log into your cluster in the {ocp-short} console.
 . Set `rwx_supported` to `false` by entering the following command:
 +
 [source,terminal]

--- a/docs/topics/mta-rn-upgrade-cli.adoc
+++ b/docs/topics/mta-rn-upgrade-cli.adoc
@@ -1,0 +1,19 @@
+// Module included in the following assemblies:
+//
+// * docs/web-console-guide/master.adoc
+
+:_content-type: PROCEDURE
+[id="mta-rn-upgrade-cli_{context}"]
+= Setting the parameter in the {ocp-short} web console after upgrading to version {ProductVersion}
+
+You can set the value of `rwx_supported` in the {ocp-short} web console after you upgrade to {ProductShortName} {ProductVersion}
+
+.Procedure
+
+. After you upgrade the {ProductShortName} Operator, log into your cluster in the {ocp-short} web console.
+. Set `rwx_supported` to `false` by entering the following command:
++
+[source,terminal]
+----
+$ oc patch tackle $(oc get tackle -n openshift-mta|grep -iv name|cut -d " " -f 1) -n openshift-mta --type merge --patch '{"spec":{"rwx_supported": "false"}}'
+----

--- a/docs/topics/mta-rn-upgrade-ui.adoc
+++ b/docs/topics/mta-rn-upgrade-ui.adoc
@@ -1,0 +1,16 @@
+// Module included in the following assemblies:
+//
+// * docs/web-console-guide/master.adoc
+
+:_content-type: PROCEDURE
+[id="mta-rn-upgrade-ui_{context}"]
+= Setting the parameter in the {WebName} after upgrading to version {ProductVersion}
+
+You can set the value of `rwx_supported` after you upgrade the {ProductShortName} {WebName}.
+
+.Procedure
+
+. After you upgrade the {ProductShortName} Operator, log into the {ocp-short} web console, click *Operators -> Installed Operators -> Migration Toolkit for Applications Operator -> Tackle*, and then click the Tackle instance,
+. Click *YAML* view.
+. Add `rwx_supported` to the CR settings that are listed in the `spec` section, and set its value to `false`.
+. Click *Save*.

--- a/docs/topics/mta-rn-upgrade-ui.adoc
+++ b/docs/topics/mta-rn-upgrade-ui.adoc
@@ -4,13 +4,13 @@
 
 :_content-type: PROCEDURE
 [id="mta-rn-upgrade-ui_{context}"]
-= Setting the parameter in the {WebName} after upgrading to version {ProductVersion}
+= Setting the parameter in the {ProductShortName} Operator after upgrading to version {ProductVersion}
 
 You can set the value of `rwx_supported` after you upgrade the {ProductShortName} {WebName}.
 
 .Procedure
 
-. After you upgrade the {ProductShortName} Operator, log into the {ocp-short} web console, click *Operators -> Installed Operators -> Migration Toolkit for Applications Operator -> Tackle*, and then click the Tackle instance,
+. After you upgrade the {ProductShortName} Operator, log into the {ocp-short} web console, click *Operators -> Installed Operators -> Migration Toolkit for Applications Operator -> Tackle*, and then click the Tackle instance.
 . Click *YAML* view.
 . Add `rwx_supported` to the CR settings that are listed in the `spec` section, and set its value to `false`.
 . Click *Save*.

--- a/docs/topics/templates/document-attributes.adoc
+++ b/docs/topics/templates/document-attributes.adoc
@@ -17,11 +17,11 @@ ifdef::mta[]
 :ProductShortName: MTA
 :LC_PSN: mta
 :DocInfoProductNameURL: migration_toolkit_for_applications
-:WebName: User Interface
+:WebName: user interface
 :WebNameTitle: User Interface
 :WebNameURL: user_interface_guide
 :WebConsoleBookName: {WebNameTitle} Guide
-:ProductVersion: 6.0.0
+:ProductVersion: 6.0.1
 :PluginName: MTA plugin
 :ProductDistributionVersion: 6.0.0.GA-redhat-00002
 :ProductDistribution: mta-6.0.0.GA-offline.zip
@@ -90,7 +90,6 @@ endif::[]
 :ProductDocWebConsoleGuideURL: https://access.redhat.com/documentation/en-us/{DocInfoProductNameURL}/{DocInfoProductNumber}/html/{WebNameURL}/index
 :ProductDocRulesGuideURL: https://access.redhat.com/documentation/en-us/{DocInfoProductNameURL}/{DocInfoProductNumber}/html-single/rules_development_guide
 :EclipseCrsGuideURL: https://access.redhat.com/documentation/en-us/{DocInfoProductNameURL}/{DocInfoProductNumber}/html-single/eclipse_and_red_hat_codeready_studio_guide
-
 :IntelliJGuideURL: https://access.redhat.com/documentation/en-us/{DocInfoProductNameURL}/{DocInfoProductNumber}/html-single/intellij_idea_plugin_guide
 :ProductDocIntroToMTAGuideURL: https://access.redhat.com/documentation/en-us/{DocInfoProductNameURL}/{DocInfoProductNumber}/html-single/introduction_to_the_{DocInfoProductNameURL}
 :ProductDocUserInterfaceGuideURL: https://access.redhat.com/documentation/en-us/{DocInfoProductNameURL}/{DocInfoProductNumber}/html-single/{WebNameURL}
@@ -101,7 +100,6 @@ endif::[]
 :OpenShiftDocsURL: https://docs.openshift.com/container-platform/{OpenShiftProductNumber}
 :LinkAPI: http://windup.github.io/windup/docs/latest/javadoc/
 
-//What about these ones?
 //Links to MTA and MTR Jira project pages:
 :JiraMTRURL: https://issues.redhat.com/projects/WINDUP
 :JiraMTAURL: https://issues.redhat.com/projects/TACKLE


### PR DESCRIPTION
MTA 6.0.1

Resolves https://issues.redhat.com/browse/MTA-94 and https://issues.redhat.com/browse/MTA-148 by creating release notes for MTA 6.0.1, including the new RWX option.

Also adds a sample YAML to the User interface user guide installation instructions.

Previews: 
1. The MTA 6.0.1 release notes: https://deploy-preview-653--windup-documentation.netlify.app/docs/release-notes/master/index.html#mta-6-0-1

2. The added YAML file: https://deploy-preview-653--windup-documentation.netlify.app/docs/web-console-guide/master/index.html#installing-the-migration-toolkit-for-applications-operator-and-the-user-interface  follows table of CR settings

