### PR TITLE
Revised MTA 6.0.1 release notes

### DIFF
--- a/docs/topics/mta-6-installing-web-console-on-openshift.adoc
+++ b/docs/topics/mta-6-installing-web-console-on-openshift.adoc
@@ -46,7 +46,7 @@ To successfully deploy, the {ProductShortName} Operator requires 3 RWO persisten
 |`cache`
 |100 GiB
 |RWX
-|Maven m2 repository; required if the `rwx_supported` configuration option is set to `true`
+|Maven m2 cache; required if the `rwx_supported` configuration option is set to `true`
 |====
 
 == Installing the {ProductName} Operator and the {WebName}
@@ -120,7 +120,7 @@ The most commonly used CR settings are listed in this table:
 
 |`maven_data_volume_size`
 |100 GiB
-|Size requested for the Maven m2 repository volume; deprecated in {ProductShortName} 6.0.1
+|Size requested for the Maven m2 cache volume; deprecated in {ProductShortName} 6.0.1
 
 |`rwx_storage_class`
 |NA

--- a/docs/topics/mta-rn-new-features-1.adoc
+++ b/docs/topics/mta-rn-new-features-1.adoc
@@ -8,6 +8,11 @@
 
 This section describes the new features and improvements of the {ProductName} ({ProductShortName}) {ProductVersion}.
 
-.Support for non-administrators to run {ProductShortName}
-For security reasons, the RWX permission set of {ProductShortName} 6.0.0 was configured to allow only administrators to run {ProductShortName}. In Version {ProductVersion}  you can now allow non-administrators to use {ProductShortName} by setting the value of a new parameter, `rwx_supported`, to `false` in the the {ProductShortName} Operator or the {ocp-first}  console.
+.{ProductShortName} no longer requires support for RWX volumes
+Previously, {ProductShortName} required support for RWX volumes, and in version {ProductVersion} this is optional. The Tackle CR includes a new configuration option, `rwx_supported`, a Boolean parameter whose default is `true`.
+
+* When this option is set to `true`, the {ProductShortName} Operator creates a cache volume as RWX. This volume is used by Maven as a durable local m2 cache that is shared across tasks.
+* When it is set to `false`, the Maven m2 cache will be local with each task. You can always configure the Maven cache separately.
+
+
 

--- a/docs/topics/mta-rn-upgrade-cli.adoc
+++ b/docs/topics/mta-rn-upgrade-cli.adoc
@@ -4,13 +4,13 @@
 
 :_content-type: PROCEDURE
 [id="mta-rn-upgrade-cli_{context}"]
-= Setting the parameter in the {ocp-short} console after upgrading to version {ProductVersion}
+= Setting the parameter in the Tackle Custom Resource (CR) using the CLI after upgrading to version {ProductVersion}
 
-You can set the value of `rwx_supported` in the {ocp-short} console after you upgrade to {ProductShortName} {ProductVersion}.
+You can set the value of `rwx_supported` in the Tackle CR using the OpenShift CLI after you upgrade to {ProductShortName} {ProductVersion}.
 
 .Procedure
 
-. After you upgrade the {ProductShortName} Operator, log into your cluster in the {ocp-short} console.
+. Log into your cluster using the OpenShift CLI.
 . Set `rwx_supported` to `false` by entering the following command:
 +
 [source,terminal]

--- a/docs/topics/mta-rn-upgrade-ui.adoc
+++ b/docs/topics/mta-rn-upgrade-ui.adoc
@@ -4,13 +4,13 @@
 
 :_content-type: PROCEDURE
 [id="mta-rn-upgrade-ui_{context}"]
-= Setting the parameter in the {ProductShortName} Operator after upgrading to version {ProductVersion}
+= Setting the parameter in the OpenShift web console after upgrading to version {ProductVersion}
 
-You can set the value of `rwx_supported` after you upgrade the {ProductShortName} {WebName}.
+You can set the value of `rwx_supported` in the OpenShift web console after you upgrade to {ProductShortName} {ProductVersion}.
 
 .Procedure
 
-. After you upgrade the {ProductShortName} Operator, log into the {ocp-short} web console, click *Operators -> Installed Operators -> Migration Toolkit for Applications Operator -> Tackle*, and then click the Tackle instance.
+. Log into the OpenShift web console, click *Operators -> Installed Operators -> Migration Toolkit for Applications Operator -> Tackle*, and then click the Tackle instance.
 . Click *YAML* view.
 . Add `rwx_supported` to the CR settings that are listed in the `spec` section, and set its value to `false`.
 . Click *Save*.


### PR DESCRIPTION
MTA 6.0.1

Resolves https://issues.redhat.com/browse/MTA-148 by changing the description of the RWX permissions feature and fixing the headings of sections 2.1.1 and 2.1.2.

Also changes "repository" to "cache" in installation instructions where needed.

Previews: 

1. https://deploy-preview-659--windup-documentation.netlify.app/docs/release-notes/master/index.html#mta-6-0-1 Revised release notes for MTA 6.0.1

2a. https://deploy-preview-659--windup-documentation.netlify.app/docs/web-console-guide/master/index.html#persistent-volume-requirements  description of "cache" PV.

2b. https://deploy-preview-659--windup-documentation.netlify.app/docs/web-console-guide/master/index.html#installing-the-migration-toolkit-for-applications-operator-and-the-user-interface  Table 2 -- description of maven_data_volume_size .