### PR TITLE
Windup 3661 mtr1 0 2rn hvider 2

### DIFF
--- a/docs/release-notes-mtr/master.adoc
+++ b/docs/release-notes-mtr/master.adoc
@@ -17,6 +17,11 @@ include::topics/making-open-source-more-inclusive.adoc[]
 
 These release notes cover all z-stream releases of {ProductShortName} 1.0 with the most recent release listed first.
 
+== {ProductShortName} 1.0.2
+include::topics/mtr-rn-new-features-1_0_2.adoc[leveloffset=+2]
+include::topics/mtr-rn-known-issues-1_0_2.adoc[leveloffset=+2]
+include::topics/mtr-rn-resolved-issues-1_0_2.adoc[leveloffset=+2]
+
 == {ProductShortName} 1.0.1
 include::topics/mtr-rn-new-features-1.adoc[leveloffset=+2]
 include::topics/mtr-rn-known-issues-1.adoc[leveloffset=+2]

--- a/docs/topics/mtr-rn-known-issues-1_0_2.adoc
+++ b/docs/topics/mtr-rn-known-issues-1_0_2.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assemblies:
+//
+// * docs/release-notes-mtr/master.adoc
+
+:_content-type: REFERENCE
+[id="mtr-rn-known-issues-1_{context}"]
+
+= Known issues
+
+For a complete list of all known issues, see the list of link:hhttps://issues.redhat.com/browse/WINDUP-3670?filter=12409779[MTR 1.0.2 known issues] in Jira.

--- a/docs/topics/mtr-rn-known-issues-1_0_2.adoc
+++ b/docs/topics/mtr-rn-known-issues-1_0_2.adoc
@@ -7,4 +7,8 @@
 
 = Known issues
 
+.link:https://issues.redhat.com/browse/WINDUP-3673[WindUp Web Console 5 and 6 cannot cross launch report in Windows]
+Accessing reports from the MTR Web Console is difficult when running on Windows.
+Workaround: Access the reports by navigating to them in the file system.
+
 For a complete list of all known issues, see the list of link:hhttps://issues.redhat.com/browse/WINDUP-3670?filter=12409779[MTR 1.0.2 known issues] in Jira.

--- a/docs/topics/mtr-rn-known-issues-1_0_2.adoc
+++ b/docs/topics/mtr-rn-known-issues-1_0_2.adoc
@@ -8,7 +8,7 @@
 = Known issues
 
 .link:https://issues.redhat.com/browse/WINDUP-3673[WindUp Web Console 5 and 6 cannot cross launch report in Windows]
-Accessing reports from the MTR Web Console is difficult when running on Windows.
+Accessing reports from the MTR Web Console is difficult on Windows.
 Workaround: Access the reports by navigating to them in the file system.
 
 For a complete list of all known issues, see the list of link:hhttps://issues.redhat.com/browse/WINDUP-3670?filter=12409779[MTR 1.0.2 known issues] in Jira.

--- a/docs/topics/mtr-rn-new-features-1_0_2.adoc
+++ b/docs/topics/mtr-rn-new-features-1_0_2.adoc
@@ -9,4 +9,4 @@
 This section describes the new features of the {ProductName} ({ProductShortName}) 1.0.2.
 
 .New Rulesets
-{ProductShortName} includes new rulesets that support migration to EAP 8 and Hibernate 6.
+{ProductShortName} includes new rulesets that supports migration to EAP 8 and Hibernate 6.

--- a/docs/topics/mtr-rn-new-features-1_0_2.adoc
+++ b/docs/topics/mtr-rn-new-features-1_0_2.adoc
@@ -9,4 +9,4 @@
 This section describes the new features of the {ProductName} ({ProductShortName}) 1.0.2.
 
 .New Rulesets
-{ProductShortName} includes new rulesets to support users migrating to EAP 8 and Hibernate 6.
+{ProductShortName} includes new rulesets that support migration to EAP 8 and Hibernate 6.

--- a/docs/topics/mtr-rn-new-features-1_0_2.adoc
+++ b/docs/topics/mtr-rn-new-features-1_0_2.adoc
@@ -1,0 +1,12 @@
+// Module included in the following assemblies:
+//
+// * docs/release_notes/master.adoc
+
+:_content-type: CONCEPT
+[id="rn-new-features-1_{context}"]
+= New features
+
+This section describes the new features of the {ProductName} ({ProductShortName}) 1.0.2.
+
+.New Rulesets
+{ProductShortName} includes new rulesets to support users migrating to EAP 8 and Hibernate 6.

--- a/docs/topics/mtr-rn-resolved-issues-1_0_2.adoc
+++ b/docs/topics/mtr-rn-resolved-issues-1_0_2.adoc
@@ -1,0 +1,9 @@
+// Module included in the following assemblies:
+//
+// * docs/release-notes-mtr/mtr_release_notes-1.0/master.adoc
+
+:_content-type: REFERENCE
+[id="mtr-rn-resolved-issues-1_{context}"]
+= Resolved issues
+
+For a complete list of all issues resolved in this release, see the list of link:https://issues.redhat.com/browse/WINDUP-3663?filter=12409778[{ProductShortName} 1.0.2 resolved issues] in Jira.

--- a/method-discover.adoc
+++ b/method-discover.adoc
@@ -1,0 +1,16 @@
+// Module included in the following assemblies:
+//
+// * docs/getting-started-guide/master.adoc
+
+:_content-type: CONCEPT
+[id="method-discover_{context}"]
+= Discover phase
+
+.Red Hat migration methodology: Discover phase
+image::RHAMT_AMM_Methodology_446947_0617_ECE_Discover.png[Red Hat Migration Methodology: Discover]
+
+The _Discover_ phase is when you gather all stakeholders and decision-makers together to understand the current state and business drivers, and to determine the migration or modernization needs.
+
+In this phase, you explore technologies and discuss potential approaches. Identify the existing pain points, concerns, requirements, and some potential challenges. Define the high-level business priorities and scope of the assessment. Determine in what ways you want to modernize your application development and delivery to allow you to innovate more rapidly.
+
+Typically, this can be covered in a day in a workshop with Red Hat experts.


### PR DESCRIPTION
@sbeskin-redhat @PhilipCattanach 
Added text and corrected text errors

mtr-rn-known-issues-1_0_2.adoc:
.link:https://issues.redhat.com/browse/WINDUP-3673[WindUp Web Console 5 and 6 cannot cross launch report in Windows]
Accessing reports from the MTR Web Console is difficult on Windows.
Workaround: Access the reports by navigating to them in the file system.

mtr-rn-new-features-1_0_2.adoc:
.New Rulesets
{ProductShortName} includes new rulesets that supports migration to EAP 8 and Hibernate 6.