### PR TITLE
WINDUP-3757: Update Eclipse/CRS Guide for CLI configuration

### DIFF
--- a/docs/eclipse-code-ready-studio-guide-mtr/master.adoc
+++ b/docs/eclipse-code-ready-studio-guide-mtr/master.adoc
@@ -25,19 +25,15 @@ include::topics/about-ide-addons.adoc[leveloffset=+2]
 include::topics/what-is-the-toolkit.adoc[leveloffset=+2]
 
 [id="installing-plugin_{context}"]
-== Installing the {PluginName}
+== Installing and configuring the {PluginName}
 
-You can install the {PluginName} in a connected or a restricted network environment.
+You can install the {PluginName} and configure it to use the {ProductShortName} CLI for analysis execution.
 
 include::topics/eclipse-installing-plugin.adoc[leveloffset=+2]
-:!eclipse-code-ready-studio-guide:
-:context: disconnected
-:disconnected:
-include::topics/eclipse-installing-plugin.adoc[leveloffset=+2]
-:!disconnected:
-:context: eclipse-code-ready-studio-guide
-:eclipse-code-ready-studio-guide:
-include::topics/eclipse-accessing-tools.adoc[leveloffset=+2]
+
+include::topics/eclipse-configuring-plugin-for-cli.adoc[leveloffset=+2]
+
+include::topics/eclipse-accessing-tools.adoc[leveloffset=+1]
 
 [id="analyzing-projects-with-plugin_{context}"]
 == Analyzing your projects with the {PluginName}

--- a/docs/topics/eclipse-configuring-plugin-for-cli.adoc
+++ b/docs/topics/eclipse-configuring-plugin-for-cli.adoc
@@ -1,0 +1,20 @@
+// Module included in the following assemblies:
+//
+// * docs/eclipse-code-ready-studio-guide/master.adoc
+
+:_content-type: PROCEDURE
+
+[id="eclipse-configuring-plugin-for-cli_{context}"]
+= Configuring the {PluginName} to use the {ProductShortName} CLI for analysis execution
+
+You can configure the {PluginName} to use the {ProductShortName} CLI for analysis execution.
+
+.Prerequisites
+
+* You have downloaded the {ProductShortName} CLI from the Developers Website or Customer Portal and installed it locally.
+
+.Procedure
+
+. Click the *Configure MTR* icon to open the configuration settings.
+. Populate the CLI field with the path to the parent directory of the CLI.
+. Click *Apply*.

--- a/docs/topics/eclipse-installing-plugin.adoc
+++ b/docs/topics/eclipse-installing-plugin.adoc
@@ -3,18 +3,11 @@
 // * docs/eclipse-code-ready-studio-guide/master.adoc
 
 :_content-type: PROCEDURE
-ifdef::eclipse-code-ready-studio-guide[]
-[id="eclipse-installing-plugin-connected-environment_{context}"]
+
+[id="eclipse-installing-plugin_{context}"]
 = Installing in a connected environment
 
-You can install the {PluginName} in a connected environment.
-endif::[]
-ifdef::disconnected[]
-[id="eclipse-installing-plugin-disconnected-environment_{context}"]
-= Installing in a disconnected environment
-
-You can install the {PluginName} in a disconnected network environment.
-endif::[]
+You need a connected environment to install the {PluginName}.
 
 The {PluginName} has been tested with the Eclipse IDE for Java Enterprise Developers 2022-03 and Red Hat CodeReady Studio 12.21.3.GA.
 
@@ -25,26 +18,13 @@ include::snippet_jdk-hardware-mac-prerequisites.adoc[]
 * JBoss Tools, installed with the link:https://www.eclipse.org/mpc/[Eclipse Marketplace Client]
 * link:http://download.eclipse.org/mylyn/releases/latest[Mylyn SDK and frameworks], installed with Eclipse
 
-ifdef::disconnected[]
-* Connected workstation for all downloads
-endif::[]
-
 .Procedure
 
-ifdef::disconnected[]
-. On a computer with network access, navigate to the {ProductName} link:{DevDownloadPageURL}[download site] and download the `{IDEPluginFilename}` file.
-endif::[]
 . Launch Eclipse or CodeReady Studio.
 . From the menu bar, select *Help* -> *Install New Software*.
 . Next to the *Work with* field, click *Add*.
 . In the *Name* field, enter `{ProductShortName}`.
-ifdef::eclipse-code-ready-studio-guide[]
 . In the *Location* field, enter `\http://download.jboss.org/jbosstools/photon/stable/updates/{LC_PSN}/` and click *OK*.
-endif::[]
-ifdef::disconnected[]
-. Next to the *Location* field, click *Archive*.
-. Select the `{IDEPluginFilename}` file and click *OK*.
-endif::[]
 . Select all the *JBoss Tools - {ProductShortName}* check boxes and click *Next*.
 . Review the installation details and click *Next*.
 . Accept the terms of the license agreement and click *Finish*.


### PR DESCRIPTION
Resolves: https://issues.redhat.com/browse/WINDUP-3757
MTR 1.1.0
Preview: https://deploy-preview-670--windup-documentation.netlify.app/docs/eclipse-code-ready-studio-guide-mtr/master/index.html#installing-plugin_eclipse-code-ready-studio-guide