### PR TITLE
MTA-145: changing the references to earlier versions

### DIFF
--- a/docs/topics/templates/document-attributes.adoc
+++ b/docs/topics/templates/document-attributes.adoc
@@ -23,7 +23,7 @@ ifdef::mta[]
 :WebConsoleBookName: {WebNameTitle} Guide
 :ProductVersion: 6.1.0
 :PluginName: MTA plugin
-:MavenProductVersion: 6.1.0.GA-redhat-00006
+:MavenProductVersion: 6.1.0.GA-redhat
 :ProductDistributionVersion: 6.1.0.GA-redhat
 :ProductDistribution: mta-6.1.0.GA-offline.zip
 :DevDownloadPageURL: https://developers.redhat.com/products/mta/download

--- a/docs/topics/templates/document-attributes.adoc
+++ b/docs/topics/templates/document-attributes.adoc
@@ -23,7 +23,7 @@ ifdef::mta[]
 :WebConsoleBookName: {WebNameTitle} Guide
 :ProductVersion: 6.1.0
 :PluginName: MTA plugin
-:MavenProductVersion: 6.1.0.GA-redhat
+:MavenProductVersion: 6.1.0.GA-redhat-00005
 :ProductDistributionVersion: 6.1.0.GA-redhat
 :ProductDistribution: mta-6.1.0.GA-offline.zip
 :DevDownloadPageURL: https://developers.redhat.com/products/mta/download

--- a/docs/topics/templates/document-attributes.adoc
+++ b/docs/topics/templates/document-attributes.adoc
@@ -13,7 +13,7 @@
 ifdef::mta[]
 :ProductName: Migration Toolkit for Applications
 :DocInfoProductName: Migration Toolkit for Applications
-:DocInfoProductNumber: 6.0
+:DocInfoProductNumber: 6.1
 :ProductShortName: MTA
 :LC_PSN: mta
 :DocInfoProductNameURL: migration_toolkit_for_applications
@@ -21,11 +21,11 @@ ifdef::mta[]
 :WebNameTitle: User Interface
 :WebNameURL: user_interface_guide
 :WebConsoleBookName: {WebNameTitle} Guide
-:ProductVersion: 6.0.1
+:ProductVersion: 6.1.0
 :PluginName: MTA plugin
-:MavenProductVersion: 6.0.1.GA-redhat-00006
-:ProductDistributionVersion: 6.0.1.GA-redhat
-:ProductDistribution: mta-6.0.1.GA-offline.zip
+:MavenProductVersion: 6.1.0.GA-redhat-00006
+:ProductDistributionVersion: 6.1.0.GA-redhat
+:ProductDistribution: mta-6.1.0.GA-offline.zip
 :DevDownloadPageURL: https://developers.redhat.com/products/mta/download
 :IDEPluginFilename: migrationtoolkit-mta-eclipse-plugin-repository
 :JiraWindupURL: https://issues.redhat.com/projects/TACKLE


### PR DESCRIPTION
[MTV-145](https://issues.redhat.com/browse/MTA-145)

Changing the document-attributes.adoc file for moving from 6.0.1 release to 6.1.0 release