### PR TITLE
Mta 451 eviction threshold hvider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,10 @@ html/
 Gemfile.lock
 */master.html
 .idea/
+.DS_Store
+docs/.DS_Store
+docs/topics/.DS_Store
+test_repo1hg
+.gitignore
+.idea/
+.idea/vcs.xml

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -2,5 +2,6 @@
 <project version="4">
   <component name="VcsDirectoryMappings">
     <mapping directory="" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/test_repo1hg" vcs="Git" />
   </component>
 </project>

--- a/docs/topics/cli-run.adoc
+++ b/docs/topics/cli-run.adoc
@@ -81,6 +81,19 @@ $ <{ProductShortName}_HOME>/bin/windup-cli -Dwindup.decompiler=procyon \
     --target <TARGET_TECHNOLOGY> --packages <PACKAGE_1> <PACKAGE_2>
 ----
 
+== Eviction Thresholdev
+
+A node running applications requires enough reserve memomory. An application can trigger an out-of-memory event when it uses more than its reserved memory.
+
+The `--eviction-hard` flag directs the node to evict applications when available memory drops below an absolute value or percentage. Set `--eviction-hard` along with memory reserves for the node.
+
+The following example illistrates node memory allocation settings:
+* Node capacity: `32 Gi`
+* `--system-reserved` setting: `3 Gi`
+* `--eviction-hard` setting: `100 Mi`
+
+This node has 28.9 Gi of effective memory available (32 Gi - 3 Gi - 0.1 Gi) before the `--eviction-hard` setting starts to evict applications that are using too much memory.
+
 [id="cli-bash-completion_{context}"]
 == {ProductShortName} {CLINameTitle} Bash completion
 

--- a/docs/topics/mta-6-installing-web-console-on-openshift.adoc
+++ b/docs/topics/mta-6-installing-web-console-on-openshift.adoc
@@ -170,7 +170,7 @@ A node running applications requires enough reserve memomory. An application can
 
 The `--eviction-hard` flag directs the node to evict applications when available memory drops below an absolute value or percentage. Set `--eviction-hard` along with memory reserves for the node.
 
-The following example illistrates node memory allocation settings:
+The following example illustrates node memory allocation settings:
 * Node capacity: `32 Gi`
 * `--system-reserved` setting: `3 Gi`
 * `--eviction-hard` setting: `100 Mi`

--- a/docs/topics/mta-6-installing-web-console-on-openshift.adoc
+++ b/docs/topics/mta-6-installing-web-console-on-openshift.adoc
@@ -164,3 +164,15 @@ The test results indicate that the minimum amount of memory for running {Product
 ** Installing the cluster monitoring tools requires an additional 5 GB of memory.
 ====
 
+== Eviction Threshold
+
+A node running applications requires enough reserve memomory. An application can trigger an out-of-memory event when it uses more than its reserved memory.
+
+The `--eviction-hard` flag directs the node to evict applications when available memory drops below an absolute value or percentage. Set `--eviction-hard` along with memory reserves for the node.
+
+The following example illistrates node memory allocation settings:
+* Node capacity: `32 Gi`
+* `--system-reserved` setting: `3 Gi`
+* `--eviction-hard` setting: `100 Mi`
+
+This node has 28.9 Gi of effective memory available (32 Gi - 3 Gi - 0.1 Gi) before the `--eviction-hard` setting starts to evict applications that are using too much memory.

--- a/docs/topics/mtr-rn-known-issues-1_0_2.adoc
+++ b/docs/topics/mtr-rn-known-issues-1_0_2.adoc
@@ -7,4 +7,8 @@
 
 = Known issues
 
+.link:https://issues.redhat.com/browse/WINDUP-3673[WindUp Web Console 5 and 6 cannot cross launch report in Windows]
+Accessing reports from the MTR Web Console is difficult when running on Windows.
+Workaround: Access the reports by navigating to them in the file system.
+
 For a complete list of all known issues, see the list of link:hhttps://issues.redhat.com/browse/WINDUP-3670?filter=12409779[MTR 1.0.2 known issues] in Jira.

--- a/docs/topics/mtr-rn-new-features-1_0_2.adoc
+++ b/docs/topics/mtr-rn-new-features-1_0_2.adoc
@@ -9,4 +9,4 @@
 This section describes the new features of the {ProductName} ({ProductShortName}) 1.0.2.
 
 .New Rulesets
-{ProductShortName} includes new rulesets to support users migrating to EAP 8 and Hibernate 6.
+{ProductShortName} includes new rulesets that support migration to EAP 8 and Hibernate 6.


### PR DESCRIPTION


mta-451_eviction-threshold_hvider
Added Eviction Threshold section to MTA CLI guide > Running the CLI and MTA User Interface Guide > Installing MTA

Added a section in the following files in windup-documentation repo:
docs/topics/cli-run.adoc
docs/topics/mta-6-installing-web-console-on-openshift.adoc

New section: Eviction Threshold
Content - 

== Eviction Threshold

A node running applications requires enough reserve memomory. An application can trigger an out-of-memory event when it uses more than its reserved memory.

The `--eviction-hard` flag directs the node to evict applications when available memory drops below an absolute value or percentage. Set `--eviction-hard` along with memory reserves for the node.

The following example illustrates node memory allocation settings:
* Node capacity: `32 Gi`
* `--system-reserved` setting: `3 Gi`
* `--eviction-hard` setting: `100 Mi`

This node has 28.9 Gi of effective memory available (32 Gi - 3 Gi - 0.1 Gi) before the `--eviction-hard` setting starts to evict applications that are using too much memory.