### PR TITLE
MTA-519 - Fixing a number of typos

### DIFF
--- a/docs/topics/about-the-user-interface.adoc
+++ b/docs/topics/about-the-user-interface.adoc
@@ -6,6 +6,6 @@
 [id="about-the-user-interface_{context}"]
 = About the {WebName}
 
-The {WebName} for the {ProductName} allows a team of users to assess and analayze applications for risks and suitability for migration to hybrid cloud environments on Red Hat OpenShift.
+The {WebName} for the {ProductName} allows a team of users to assess and analyze applications for risks and suitability for migration to hybrid cloud environments on Red Hat OpenShift.
 
 Use the {WebName} to assess and analyze your applications to get insights about potential pitfalls in the adoption process, at both the portfolio and application levels as you inventory, assess, analyze, and manage applications for faster migration to OpenShift.

--- a/docs/topics/mta-web-config-git-repos.adoc
+++ b/docs/topics/mta-web-config-git-repos.adoc
@@ -6,7 +6,7 @@
 [id="mta-web-config-git-repos_{context}"]
 = Configuring Git repositories
 
-You can configure Git respositories in the *Repositories* view of the {ProductName} ({ProductShortName}) {WebName}.
+You can configure Git repositories in the *Repositories* view of the {ProductName} ({ProductShortName}) {WebName}.
 
 .Procedure
 

--- a/docs/topics/mta-web-config-http-https-proxy.adoc
+++ b/docs/topics/mta-web-config-http-https-proxy.adoc
@@ -6,7 +6,7 @@
 [id="mta-web-config-http-https-proxy_{context}"]
 = Configuring HTTP and HTTPS proxy settings
 
-You can configure HTTP and HTTPS proxy settings respositories in the *Administration* view of the {ProductName} ({ProductShortName}) {WebName}.
+You can configure HTTP and HTTPS proxy settings repositories in the *Administration* view of the {ProductName} ({ProductShortName}) {WebName}.
 
 .Procedure
 

--- a/docs/topics/mta-web-config-subversion-repos.adoc
+++ b/docs/topics/mta-web-config-subversion-repos.adoc
@@ -6,7 +6,7 @@
 [id="mta-web-config-subversion-repos_{context}"]
 = Configuring subversion repositories
 
-You can configure subversion respositories in the *Repositories* view of the {ProductName} ({ProductShortName}) {WebName}.
+You can configure subversion repositories in the *Repositories* view of the {ProductName} ({ProductShortName}) {WebName}.
 
 .Procedure
 

--- a/docs/topics/mta-what-is-the-toolkit.adoc
+++ b/docs/topics/mta-what-is-the-toolkit.adoc
@@ -17,7 +17,7 @@
 
 {ProductName} ({ProductShortName}) accelerates large-scale application modernization efforts across hybrid cloud environments on Red Hat OpenShift. This solution provides insight throughout the adoption process, at both the portfolio and application levels: inventory, assess, analyze, and manage applications for faster migration to OpenShift via the user interface.
 
-{ProductShortName} uses an extensive questionaire as the the basis for assessing your applications, enabling you to estimate the difficulty, time, and other resources needed to prepare an application for containerization. You can use the results of an assessment as the basis for discussions between stakeholders to determine which applications are good candidates for containerization, which require significant work first, and which are not suitable for containerization.
+{ProductShortName} uses an extensive questionnaire as the basis for assessing your applications, enabling you to estimate the difficulty, time, and other resources needed to prepare an application for containerization. You can use the results of an assessment as the basis for discussions between stakeholders to determine which applications are good candidates for containerization, which require significant work first, and which are not suitable for containerization.
 
 {ProductShortName} analyzes applications by applying one or more rulesets to each application considered to determine which specific lines of that application must be modified before it can be modernized.
 
@@ -29,7 +29,7 @@
 * Migrating from Java Spring Boot to Quarkus
 * Upgrading from OpenJDK 8 to OpenJDK 11
 * Upgrading from OpenJDK 11 to OpenJDK 17
-* Migrating EAP Java applicatons to Azure App Service
+* Migrating EAP Java applications to Azure App Service
 * Migrating Spring Boot Java applications to Azure App Service
 
 For more information about use cases and migration paths, see the link:https://developers.redhat.com/products/mta/use-cases[{ProductShortName} for developers] web page.

--- a/docs/topics/new-mta-features.adoc
+++ b/docs/topics/new-mta-features.adoc
@@ -16,6 +16,6 @@ Now designed for easier upgrades with more migration paths, {ProductShortName} i
 
 * *Improved analysis capabilities* with new analysis modes, including source and dependency modes that parse repositories to gather dependencies and add them to the overall scope of the analysis. There is also a simplified user experience to configure the analysis scope, including open source libraries.
 
-* *Enhanced Role-Bassed Access Control (RBAC)* powered by link:https://access.redhat.com/products/red-hat-single-sign-on[Red Hat Single Sign-On], defining three new differentiated personas with different permissions to suit the needs of each user—administrator, architect and migrator—including credentials management for multiple credential types.
+* *Enhanced Role-Based Access Control (RBAC)* powered by link:https://access.redhat.com/products/red-hat-single-sign-on[Red Hat Single Sign-On], defining three new differentiated personas with different permissions to suit the needs of each user—administrator, architect and migrator—including credentials management for multiple credential types.
 
 * *Administration perspective* to provide tool-wide configuration management for administrators.

--- a/docs/topics/xml-rule-syntax.adoc
+++ b/docs/topics/xml-rule-syntax.adoc
@@ -26,7 +26,7 @@ A ruleset is a group of one or more rules that targets a specific area of migrat
 **** **<otherwise>**: The action to be performed when the rule condition is not matched. This element takes the same child elements as the `<perform>` element.
 **** **<where>**: A string pattern defined as a parameter, which can be used elsewhere in the rule definition.
 *** **<file-mapping/>**: Maps an extension to a graph type.
-*** **<package-mapping/>**: Maps from a package pattern (regular expression) to a organization name.
+*** **<package-mapping/>**: Maps from a package pattern (regular expression) to an organization name.
 
 == Predefined rules
 


### PR DESCRIPTION
[MTA-519](https://issues.redhat.com/browse/MTA-519)

Fixing a number of typos:



/windup-documentation/topics/mta-what-is-the-toolkit.adoc:

**questionaire as the the** changed to **questionnaire as the**

"Migrating EAP Java applicatons to Azure App Service"

/windup-documentation/topics/new-mta-features.adoc:

**Enhanced Role-Bassed Access Control** changed to  **Enhanced Role-Based Access Control**

/windup-documentation/topics/about-the-user-interface.adoc:

**users to assess and analayze applications** changed to **users to assess and analayze applications**
 

/windup-documentation/topics/mta-web-config-git-repos.adoc:

/windup-documentation/topics/mta-web-config-http-https-proxy.adoc:

/windup-documentation/topics/mta-web-config-subversion-repos.adoc:

**respositories** changed to **repositories**

/windup-documentation/topics/xml-rule-syntax.adoc:
 
**to a organization name** changed to **to an organization name**.
