### PR TITLE
MTA-524: updating attributes for MTA-6.1.1 GA

### DIFF
--- a/docs/topics/templates/document-attributes.adoc
+++ b/docs/topics/templates/document-attributes.adoc
@@ -21,11 +21,11 @@ ifdef::mta[]
 :WebNameTitle: User Interface
 :WebNameURL: user_interface_guide
 :WebConsoleBookName: {WebNameTitle} Guide
-:ProductVersion: 6.1.0
+:ProductVersion: 6.1.1
 :PluginName: MTA plugin
-:MavenProductVersion: 6.1.0.GA-redhat-00005
-:ProductDistributionVersion: 6.1.0.GA-redhat
-:ProductDistribution: mta-6.1.0.GA-offline.zip
+:MavenProductVersion: 6.1.1.GA-redhat-00005
+:ProductDistributionVersion: 6.1.1.GA-redhat
+:ProductDistribution: mta-6.1.1.GA-offline.zip
 :DevDownloadPageURL: https://developers.redhat.com/products/mta/download
 :IDEPluginFilename: migrationtoolkit-mta-eclipse-plugin-repository
 :JiraWindupURL: https://issues.redhat.com/projects/TACKLE

--- a/docs/topics/templates/document-attributes.adoc
+++ b/docs/topics/templates/document-attributes.adoc
@@ -23,9 +23,9 @@ ifdef::mta[]
 :WebConsoleBookName: {WebNameTitle} Guide
 :ProductVersion: 6.1.1
 :PluginName: MTA plugin
-:MavenProductVersion: 6.1.1.GA-redhat-00005
-:ProductDistributionVersion: 6.1.1.GA-redhat
-:ProductDistribution: mta-6.1.1.GA-offline.zip
+:MavenProductVersion: 6.1.1.CR1-redhat-00001
+:ProductDistributionVersion: 6.1.1.CR1-redhat
+:ProductDistribution: mta-6.1.1-cli-offline.zip
 :DevDownloadPageURL: https://developers.redhat.com/products/mta/download
 :IDEPluginFilename: migrationtoolkit-mta-eclipse-plugin-repository
 :JiraWindupURL: https://issues.redhat.com/projects/TACKLE


### PR DESCRIPTION
Updating the attributes doc to update references to 6.1.1

Please can I ask for verification of the names of the new packages.

Lines 26 to 28:

:MavenProductVersion: 6.1.1.GA-redhat-00005
:ProductDistributionVersion: 6.1.1.GA-redhat
:ProductDistribution: mta-6.1.1.GA-offline.zip

Thanks 