### PR TITLE
add changes to fix error of rn-known-issues-1_release-notes

### DIFF
--- a/docs/topics/mta-rn-known-issues-6-1-0.adoc
+++ b/docs/topics/mta-rn-known-issues-6-1-0.adoc
@@ -3,7 +3,7 @@
 // * docs/release_notes/master-6-1-0.adoc
 
 :_content-type: REFERENCE
-[id="rn-known-issues-1_{context}"]
+[id="rn-known-issues-610_{context}"]
 = Known issues
 
 At the time of the release, the following known issue has been identified.

--- a/docs/topics/mta-rn-known-issues-6-1-1.adoc
+++ b/docs/topics/mta-rn-known-issues-6-1-1.adoc
@@ -3,7 +3,7 @@
 // * docs/release_notes/master-6-1-0.adoc
 
 :_content-type: REFERENCE
-[id="rn-known-issues-1_{context}"]
+[id="rn-known-issues-611_{context}"]
 = Known issues
 
 At the time of release, there are no known issues in this release.

--- a/docs/topics/mta-rn-resolved-issues-6-1-0.adoc
+++ b/docs/topics/mta-rn-resolved-issues-6-1-0.adoc
@@ -3,7 +3,7 @@
 // * docs/release_notes/master-6-1-0.adoc
 
 :_content-type: REFERENCE
-[id="mta-rn-resolved-issues-1_{context}"]
+[id="mta-rn-resolved-issues-610_{context}"]
 = Resolved issues
 
 For a complete list of all issues resolved in this release, see the list of link:https://issues.redhat.com/browse/MTA-279?filter=12413846[{ProductShortName} 6.1.0 resolved issues] in Jira.

--- a/docs/topics/mta-rn-resolved-issues-6-1-1.adoc
+++ b/docs/topics/mta-rn-resolved-issues-6-1-1.adoc
@@ -3,7 +3,7 @@
 // * docs/release_notes/master-6-1-0.adoc
 
 :_content-type: REFERENCE
-[id="mta-rn-resolved-issues-1_{context}"]
+[id="mta-rn-resolved-issues-611_{context}"]
 = Resolved issues
 
 At the time of the release, the following resolved issue has been identified as the major issue worth highlighting:


### PR DESCRIPTION
Adding fixes to address:

[31m[1mID "rn-known-issues-1_release-notes" is duplicated in the source content[0m
[31m[1mID "mta-rn-resolved-issues-1_release-notes" is duplicated in the source content[0m
[31m[1m/var/lib/jenkins/workspace/doc-migration_toolkit_for_applications-6.1-release_notes-en-US (stage)/docs/release-notes/build/en-US/master.xml fails to validate[0m
Build step 'Execute shell' marked build as failure 