### PR TITLE
WINDUP-3603 Run Windup on OpenJDK17 - Changes to Docs

### DIFF
--- a/docs/topics/eclipse-installing-plugin.adoc
+++ b/docs/topics/eclipse-installing-plugin.adoc
@@ -12,7 +12,15 @@ You need a connected environment to install the {PluginName}.
 The {PluginName} has been tested with the Eclipse IDE for Java Enterprise Developers 2022-03 and Red Hat CodeReady Studio 12.21.3.GA.
 
 .Prerequisites
-include::snippet_jdk-hardware-mac-prerequisites.adoc[]
+
+* Java Development Kit (JDK) installed. {ProductShortName} supports the following JDKs:
+
+** OpenJDK 11
+** Oracle JDK 11
+** Eclipse Temurin™ JDK 11
+
+* 8 GB RAM
+* macOS installation: the value of `maxproc` must be `2048` or greater.
 
 * link:{CodeReadyStudioDownloadPageURL}[Red Hat CodeReady Studio] _or_ link:https://www.eclipse.org/downloads/packages/release/2022-03/r/eclipse-ide-java-developers[Eclipse IDE for Java Enterprise Developers 2022-03]
 * JBoss Tools, installed with the link:https://www.eclipse.org/mpc/[Eclipse Marketplace Client]

--- a/docs/topics/snippet_jdk-hardware-mac-prerequisites.adoc
+++ b/docs/topics/snippet_jdk-hardware-mac-prerequisites.adoc
@@ -2,7 +2,11 @@
 * Java Development Kit (JDK) installed. {ProductShortName} supports the following JDKs:
 
 ** OpenJDK 11
+** OpenJDK 17
 ** Oracle JDK 11
+** Oracle JDK 17
+** Eclipse Temurin™ JDK 11
+** Eclipse Temurin™ JDK 17
 
 * 8 GB RAM
 * macOS installation: the value of `maxproc` must be `2048` or greater.


### PR DESCRIPTION
Resolves: https://issues.redhat.com/browse/WINDUP-3603
MTR 1.1.0
Preview: 
https://deploy-preview-687--windup-documentation.netlify.app/docs/cli-guide-mtr/master/index.html#installing-web-console-or-cli-tool_cli-guide
https://deploy-preview-687--windup-documentation.netlify.app/docs/web-console-guide-mtr/master/index.html#installing-web-console-linux-win-mac_web-console-guide
https://deploy-preview-687--windup-documentation.netlify.app/docs/eclipse-code-ready-studio-guide-mtr/master/index.html#eclipse-installing-plugin_eclipse-code-ready-studio-guide
https://deploy-preview-687--windup-documentation.netlify.app/docs/intellij-idea-plugin-guide-mtr/master/index.html#intellij-idea-plugin-extension_idea-plugin-guide
https://deploy-preview-687--windup-documentation.netlify.app/docs/vs-code-extension-guide-mtr/master/index.html#installing-vs-code-extension_vsc-extension-guide-mtr

