### PR TITLE
WINDUP-3694: MTR1.1.0-attributes update

### DIFF
--- a/docs/topics/templates/document-attributes.adoc
+++ b/docs/topics/templates/document-attributes.adoc
@@ -35,7 +35,7 @@ endif::[]
 ifdef::mtr[]
 :ProductName: Migration Toolkit for Runtimes
 :DocInfoProductName: Migration Toolkit for Runtimes
-:DocInfoProductNumber: 1.0
+:DocInfoProductNumber: 1.1
 :ProductShortName: MTR
 :LC_PSN: mtr
 :DocInfoProductNameURL: migration_toolkit_for_runtimes
@@ -43,10 +43,10 @@ ifdef::mtr[]
 :WebNameTitle: Web Console
 :WebNameURL: web_console_guide
 :WebConsoleBookName: {WebNameTitle} Guide
-:ProductVersion: 1.0.2
+:ProductVersion: 1.1.0
 :PluginName: MTR plugin
-:ProductDistributionVersion: 1.0.2.GA-redhat-00001
-:ProductDistribution: mtr-1.0.2.GA-offline
+:ProductDistributionVersion: 1.1.0.GA-redhat-00003
+:ProductDistribution: mtr-1.1.0.GA-offline
 :DevDownloadPageURL: https://developers.redhat.com/products/mtr/download
 :IDEPluginFilename: migrationtoolkit-mtr-eclipse-plugin-repository
 :JiraWindupURL: https://issues.redhat.com/projects/WINDUP


### PR DESCRIPTION
[WINDUP-3694](https://issues.redhat.com/browse/WINDUP-3694): MTR1.1.0-attributes update.

changes made to `document-attributes.adoc` lines 35 to 54

```
ifdef::mtr[]
    > :ProductName: Migration Toolkit for Runtimes
    > :DocInfoProductName: Migration Toolkit for Runtimes
    > :DocInfoProductNumber: 1.1
    > :ProductShortName: MTR
    > :LC_PSN: mtr
    > :DocInfoProductNameURL: migration_toolkit_for_runtimes
    > :WebName: web console
    > :WebNameTitle: Web Console
    > :WebNameURL: web_console_guide
    > :WebConsoleBookName: {WebNameTitle} Guide
    > :ProductVersion: 1.1.0
    > :PluginName: MTR plugin
    > :ProductDistributionVersion: 1.1.0.GA-redhat-00003
    > :ProductDistribution: mtr-1.1.0.GA-offline
    > :DevDownloadPageURL: https://developers.redhat.com/products/mtr/download
    > :IDEPluginFilename: migrationtoolkit-mtr-eclipse-plugin-repository
    > :JiraWindupURL: https://issues.redhat.com/projects/WINDUP
    :CodeReadyStudioDownloadPageURL: http://download.jboss.org/jbosstools/photon/stable/updates/mtr/
endif::[]
```
