### PR TITLE
Fixing error in MTR 1.1.0 release notes: duplicate IDs

### DIFF
--- a/docs/topics/mtr-rn-known-issues-1_1_0.adoc
+++ b/docs/topics/mtr-rn-known-issues-1_1_0.adoc
@@ -3,7 +3,7 @@
 // * docs/release-notes-mtr/master.adoc
 
 :_content-type: REFERENCE
-[id="mtr-rn-known-issues-1_{context}"]
+[id="mtr-rn-known-issues-11_{context}"]
 
 = Known issues
 

--- a/docs/topics/mtr-rn-new-features-1_1_0.adoc
+++ b/docs/topics/mtr-rn-new-features-1_1_0.adoc
@@ -3,7 +3,7 @@
 // * docs/release_notes/master.adoc
 
 :_content-type: CONCEPT
-[id="rn-new-features-1_{context}"]
+[id="rn-new-features-11_{context}"]
 = New features
 
 This section describes the new features of the {ProductName} ({ProductShortName}) 1.1.0.

--- a/docs/topics/mtr-rn-resolved-issues-1_1_0.adoc
+++ b/docs/topics/mtr-rn-resolved-issues-1_1_0.adoc
@@ -3,7 +3,7 @@
 // * docs/release-notes-mtr/mtr_release_notes-1.0/master.adoc
 
 :_content-type: REFERENCE
-[id="mtr-rn-resolved-issues-1_{context}"]
+[id="mtr-rn-resolved-issues-11_{context}"]
 = Resolved issues
 
 For a complete list of all issues resolved in this release, see the list of link:https://issues.redhat.com/browse/WINDUPRULE-974?jql=project%20in%20(WINDUP%2C%20WINDUPRULE)%20AND%20status%20in%20(Verified%2C%20%22Release%20Pending%22%2C%20Closed)%20AND%20issuetype%20%3D%20Bug%20AND%20fixVersion%20in%20(MTR-1.1.0)%20ORDER%20BY%20component%20DESC[{ProductShortName} 1.1.0. resolved issues] in Jira.


### PR DESCRIPTION
Fixing broken IDs in MTR 1.1.0 release notes