### PR TITLE
WINDUP-3946: release notes for MTR 1.1.1 cgo release

### DIFF
--- a/docs/release-notes-mtr/master.adoc
+++ b/docs/release-notes-mtr/master.adoc
@@ -17,6 +17,9 @@ include::topics/making-open-source-more-inclusive.adoc[]
 
 These release notes cover all releases of {ProductShortName} with the most recent release listed first.
 
+== {ProductShortName} 1.1.1
+include::topics/mtr-rn-cgo-1_1_1.adoc[leveloffset=+2]
+
 == {ProductShortName} 1.1.0
 include::topics/mtr-rn-new-features-1_1_0.adoc[leveloffset=+2]
 include::topics/mtr-rn-known-issues-1_1_0.adoc[leveloffset=+2]

--- a/docs/release-notes-mtr/master.adoc
+++ b/docs/release-notes-mtr/master.adoc
@@ -19,6 +19,7 @@ These release notes cover all releases of {ProductShortName} with the most recen
 
 == {ProductShortName} 1.1.1
 include::topics/mtr-rn-cgo-1_1_1.adoc[leveloffset=+2]
+include::topics/mtr-rn-resolved-issues-1_1_1.adoc[leveloffset=+2]
 
 == {ProductShortName} 1.1.0
 include::topics/mtr-rn-new-features-1_1_0.adoc[leveloffset=+2]

--- a/docs/topics/mtr-rn-cgo-1_1_1.adoc
+++ b/docs/topics/mtr-rn-cgo-1_1_1.adoc
@@ -6,4 +6,4 @@
 [id="mtr-rn-cgo-1-1-1_{context}"]
 = Container grade release
 
-This release is a Container Grade Only (CGO) release.
+This release contains an upgrade to the container images.

--- a/docs/topics/mtr-rn-cgo-1_1_1.adoc
+++ b/docs/topics/mtr-rn-cgo-1_1_1.adoc
@@ -1,0 +1,9 @@
+// Module included in the following assemblies:
+//
+// * docs/release_notes/master-6-1-0.adoc
+
+:_content-type: CONCEPT
+[id="mtr-rn-cgo-1-1-1_{context}"]
+= Container grade release
+
+This release is a Container Grade Only (CGO) release.

--- a/docs/topics/mtr-rn-resolved-issues-1_1_1.adoc
+++ b/docs/topics/mtr-rn-resolved-issues-1_1_1.adoc
@@ -1,0 +1,11 @@
+// Module included in the following assemblies:
+//
+// * docs/release-notes-mtr/mtr_release_notes-1.0/master.adoc
+
+:_content-type: REFERENCE
+[id="mtr-rn-resolved-issues-111_{context}"]
+= Resolved issues
+
+For a complete list of all issues resolved in this release, see the list of link:https://issues.redhat.com/issues/?filter=12403083[{ProductShortName} 1.1.1 resolved issues] in Jira.
+
+

--- a/docs/topics/mtr-rn-resolved-issues-1_1_1.adoc
+++ b/docs/topics/mtr-rn-resolved-issues-1_1_1.adoc
@@ -6,6 +6,6 @@
 [id="mtr-rn-resolved-issues-111_{context}"]
 = Resolved issues
 
-For a complete list of all issues resolved in this release, see the list of link:https://issues.redhat.com/issues/?filter=12403083[{ProductShortName} 1.1.1 resolved issues] in Jira.
+For a complete list of all issues resolved in this release, see the list of link:https://issues.redhat.com/issues/?filter=12416995[{ProductShortName} 1.1.1 resolved issues] in Jira.
 
 


### PR DESCRIPTION
[WINDUP-3946](https://issues.redhat.com/browse/WINDUP-3946)

Release Notes for MTR 1.1.1

Adding release notes to cover CGO only release

Direct preview - https://deploy-preview-709--windup-documentation.netlify.app/docs/release-notes-mtr/master/index.html#mtr-rn-resolved-issues-111_release-notes