### PR TITLE
Updating supported versions of OpenShift

### DIFF
--- a/docs/topics/mta-6-installing-web-console-on-openshift.adoc
+++ b/docs/topics/mta-6-installing-web-console-on-openshift.adoc
@@ -51,12 +51,12 @@ To successfully deploy, the {ProductShortName} Operator requires 3 RWO persisten
 
 == Installing the {ProductName} Operator and the {WebName}
 
-You can install the {ProductName} ({ProductShortName}) and the {WebName} on OpenShift Container Platform versions 4.9-4.12 when you install the {ProductName} Operator.
+You can install the {ProductName} ({ProductShortName}) and the {WebName} on OpenShift Container Platform versions 4.10-4.14 when you install the {ProductName} Operator.
 
 .Prerequisites
 
 * 4 vCPUs, 8 GiB RAM, and 40 GB persistent storage.
-* OpenShift Container Platform 4.9-4.11 installed.
+* OpenShift Container Platform 4.10-4.14 installed.
 * You must be logged in as a user with `cluster-admin` permissions.
 
 .Procedure


### PR DESCRIPTION
Updating the supported versions of OpenShift in the prerequisistes:

Shveta Sachdeva, Yesterday 7:41 PM
Hi Andy we have tested on openshift version 4.12,4.13 and 4.14


Robyn Haignere, Yesterday 8:24 PM - I asked John and he sent me to Franco and Rayford - so I sent the ? to them. 
Hey, the answer is that 6.2.0 is 4.10+ (MTA 6.2.0 claims support (publishes in to indexes) for OCP v4.10+)
