### PR TITLE
Updating level 2 headers and adding IDs

### DIFF
--- a/docs/topics/create-first-xml-rule.adoc
+++ b/docs/topics/create-first-xml-rule.adoc
@@ -10,7 +10,7 @@ This section guides you through the process of creating and testing your first {
 
 In this example, you will write a rule to discover instances where an application defines a `jboss-web.xml` file containing a `<class-loading>` element and provide a link to the documentation that describes how to migrate the code.
 
-[discrete]
+[id="creating-directory-structure-for-the-rule_{context}"]
 == Creating the directory structure for the rule
 
 Create a directory structure to contain your first rule and the data file to use for testing.
@@ -23,7 +23,7 @@ $ mkdir -p /home/<USER_NAME>/migration-rules/data
 
 This directory structure will also be used to hold the generated {ProductShortName} reports.
 
-[discrete]
+[id="mta-creating-data-to-test-the-rule_{context}"]
 == Creating data to test the rule
 
 . Create a `jboss-web.xml` file in the `/home/<USER_NAME>/migration-rules/data/` subdirectory.
@@ -192,7 +192,8 @@ The rule is now complete and should look like the following example.
 </ruleset>
 ----
 []
-[discrete]
+
+[id="mta-installing-rule-in-directory_{context}"]
 == Installing the rule
 
 An {ProductShortName} rule is installed by placing the rule into the appropriate directory.
@@ -204,7 +205,8 @@ Copy the `JBoss5-web-class-loading.windup.xml` file to the `<{ProductShortName}_
 $ cp /home/<USER_NAME>/migration-rules/rules/JBoss5-web-class-loading.windup.xml <{ProductShortName}_HOME>/rules/
 ----
 []
-[discrete]
+
+[id="mta-testing-the-rule_{context}"]
 == Testing the rule
 
 Open a terminal and run the following command, passing the test file as an input argument and a directory for the output report.
@@ -222,7 +224,7 @@ Report created: /home/<USER_NAME>/migration-rules/reports/index.html
               Access it at this URL: file:///home/<USER_NAME>/migration-rules/reports/index.html
 ----
 []
-[discrete]
+[id="mta-reviewing-the-report_{context}"]
 == Reviewing the reports
 
 Review the report to be sure that it provides the expected results. For a more detailed walkthrough of {ProductShortName} reports, see the link:{ProductDocUserGuideURL}#review-reports_cli-guide[Reviewing the reports] section of the {ProductShortName} _{UserCLIBookName}_.

--- a/docs/topics/review-quickstarts.adoc
+++ b/docs/topics/review-quickstarts.adoc
@@ -13,7 +13,6 @@ Each quickstart has a `README.adoc` file that contains instructions for that qui
 You can download a `.zip` file of the latest version of the quickstarts. If you prefer to work with the source code, you can fork and clone the `windup-quickstarts` project repository.
 
 [id="download_quickstart_zip_{context}"]
-[discrete]
 == Downloading the latest quickstart
 
 You can download the latest release of a quickstart.
@@ -27,7 +26,6 @@ You can download the latest release of a quickstart.
 You can review the quickstart `README.adoc` file.
 
 [id="use-quickstart-github-project_{context}"]
-[discrete]
 == Forking and cloning the quickstart GitHub project
 
 You can fork and clone the Quickstart Github project on your local machine.

--- a/docs/topics/rule-categories.adoc
+++ b/docs/topics/rule-categories.adoc
@@ -14,7 +14,6 @@ Although {ProductShortName} processes rules with the legacy `severity` field, yo
 ====
 
 [id="add_custom_category_{context}"]
-[discrete]
 == Adding a custom category
 
 You can add a custom category to the rule category file.
@@ -46,7 +45,6 @@ You can add a custom category to the rule category file.
 This category is ready to be referenced by {ProductShortName} rules.
 
 [id="assign_custom_category_{context}"]
-[discrete]
 == Assigning a rule to a custom category
 
 You can assign a rule to your new custom category.


### PR DESCRIPTION
**NOT URGENT**

@RichardHoch - will tidy up later and include links so you see the docs, but please let me get there 
Thanks

## Preview:
* https://deploy-preview-734--windup-documentation.netlify.app/docs/rules-development-guide/master/#creating-directory-structure-for-the-rule_rules-development-guide
* https://deploy-preview-734--windup-documentation.netlify.app/docs/rules-development-guide/master/#review-quickstarts_rules-development-guide
* https://deploy-preview-734--windup-documentation.netlify.app/docs/rules-development-guide/master/#rule-categories_rules-development-guide

## Review
Chapters 2 and 6 have some unnumbered headings that I think should be numbered. Probably not worth holding up publication but might be worth a Jira down the road.
* Section 2.1: [https://dxp-docp-prod.apps.ext-waf.spoke.prod.us-west-2.aws.paas.redhat.com/documentation/en-us/migration_tool[…]lopment_guide/index?lb_target=stage](https://dxp-docp-prod.apps.ext-waf.spoke.prod.us-west-2.aws.paas.redhat.com/documentation/en-us/migration_toolkit_for_applications/6.2/html-single/rules_development_guide/index?lb_target=stage#getting-started-rules_rules-development-guide)
* Section 2.2: [https://dxp-docp-prod.apps.ext-waf.spoke.prod.us-west-2.aws.paas.redhat.com/documentation/en-us/migration_tool[…]lopment_guide/index?lb_target=stage](https://dxp-docp-prod.apps.ext-waf.spoke.prod.us-west-2.aws.paas.redhat.com/documentation/en-us/migration_toolkit_for_applications/6.2/html-single/rules_development_guide/index?lb_target=stage#review-quickstarts_rules-development-guide)
* Chapter 6: [https://dxp-docp-prod.apps.ext-waf.spoke.prod.us-west-2.aws.paas.redhat.com/documentation/en-us/migration_tool[…]lopment_guide/index?lb_target=stage](https://dxp-docp-prod.apps.ext-waf.spoke.prod.us-west-2.aws.paas.redhat.com/documentation/en-us/migration_toolkit_for_applications/6.2/html-single/rules_development_guide/index?lb_target=stage#rule-categories_rules-development-guide)