### PR TITLE
Windup 3997 mtr 1 2 0 release notes hvider 

### DIFF
--- a/docs/release-notes-mtr/master.adoc
+++ b/docs/release-notes-mtr/master.adoc
@@ -17,28 +17,9 @@ include::topics/making-open-source-more-inclusive.adoc[]
 
 These release notes cover all releases of {ProductShortName} with the most recent release listed first.
 
-== {ProductShortName} 1.1.1
-include::topics/mtr-rn-cgo-1_1_1.adoc[leveloffset=+2]
-include::topics/mtr-rn-resolved-issues-1_1_1.adoc[leveloffset=+2]
-
-== {ProductShortName} 1.1.0
-include::topics/mtr-rn-new-features-1_1_0.adoc[leveloffset=+2]
-include::topics/mtr-rn-known-issues-1_1_0.adoc[leveloffset=+2]
-include::topics/mtr-rn-resolved-issues-1_1_0.adoc[leveloffset=+2]
-
-== {ProductShortName} 1.0.2
-include::topics/mtr-rn-new-features-1_0_2.adoc[leveloffset=+2]
-include::topics/mtr-rn-known-issues-1_0_2.adoc[leveloffset=+2]
-include::topics/mtr-rn-resolved-issues-1_0_2.adoc[leveloffset=+2]
-
-== {ProductShortName} 1.0.1
-include::topics/mtr-rn-new-features-1.adoc[leveloffset=+2]
-include::topics/mtr-rn-known-issues-1.adoc[leveloffset=+2]
-include::topics/mtr-rn-resolved-issues-1.adoc[leveloffset=+2]
-
-== {ProductShortName} 1.0.0
-include::topics/mtr-rn-new-features.adoc[leveloffset=+2]
-include::topics/mtr-rn-known-issues.adoc[leveloffset=+2]
-include::topics/mtr-rn-resolved-issues.adoc[leveloffset=+2]
+== {ProductShortName} 1.2.0
+include::topics/mtr-rn-new-features-1-2-0.adoc[leveloffset=+2]
+include::topics/mtr-rn-known-issues-1-2-0.adoc[leveloffset=+2]
+include::topics/mtr-rn-resolved-issues-1-2-0.adoc[leveloffset=+2]
 
 :!release-notes:

--- a/docs/release-notes-mtr/master.adoc
+++ b/docs/release-notes-mtr/master.adoc
@@ -15,7 +15,7 @@ include::topics/making-open-source-more-inclusive.adoc[]
 == Introduction
 {ProductName} ({ProductShortName}) provides an extensible and customizable rule-based tool that simplifies the migration and modernization of Java applications, such as migrating JBoss Enterprise Application Platform (EAP) 7 to 8 or migrating from any other application server towards EAP at scale. {ProductShortName} provides the same migration solution as provided in the Migration Toolkit for Applications 5 releases.
 
-These release notes cover all releases of {ProductShortName} with the most recent release listed first.
+These release notes cover all Z-stream releases of {ProductShortName} 1.2 with the most recent release listed first..
 
 == {ProductShortName} 1.2.0
 include::topics/mtr-rn-new-features-1-2-0.adoc[leveloffset=+2]

--- a/docs/topics/mta-rn-new-features-6-2-0.adoc
+++ b/docs/topics/mta-rn-new-features-6-2-0.adoc
@@ -9,12 +9,12 @@
 
 This section describes the new features of the Migration Toolkit for Applications (MTA) 6.2.0.
 
-.Integration with JIRA
+.xref:../../../docs/web-console-guide/master.adoc#creating-configuring-jira-connection[Integration with JIRA]
 
 The integration of {ProductName} with Jira allows you to track and manage the whole migration process. To introduce changes to the applications in the portfolio, you can create issues in Jira and assign them to developers.
 
 
-.Migration Waves management
+.xref:../../../docs/web-console-guide/master.adoc#mta-web-creating-migration-waves_user-interface-guide[Migration Waves management]
 
 A migration wave is a small collection of workloads that deliver business value. {ProductShortName}'s _Migration Wave_ groups applications to be migrated on a specified schedule.
 

--- a/docs/topics/mta-rn-new-features-6-2-0.adoc
+++ b/docs/topics/mta-rn-new-features-6-2-0.adoc
@@ -9,12 +9,12 @@
 
 This section describes the new features of the Migration Toolkit for Applications (MTA) 6.2.0.
 
-.xref:../../../docs/web-console-guide/master.adoc#creating-configuring-jira-connection[Integration with JIRA]
+.Integration with JIRA
 
 The integration of {ProductName} with Jira allows you to track and manage the whole migration process. To introduce changes to the applications in the portfolio, you can create issues in Jira and assign them to developers.
 
 
-.xref:../../../docs/web-console-guide/master.adoc#mta-web-creating-migration-waves_user-interface-guide[Migration Waves management]
+.Migration Waves management
 
 A migration wave is a small collection of workloads that deliver business value. {ProductShortName}'s _Migration Wave_ groups applications to be migrated on a specified schedule.
 

--- a/docs/topics/mtr-rn-known-issues-1-2-0.adoc
+++ b/docs/topics/mtr-rn-known-issues-1-2-0.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assemblies:
+//
+// * docs/release-notes-mtr/master.adoc
+
+:_content-type: REFERENCE
+[id="mtr-rn-known-issues-1-2-0_{context}"]
+
+= Known issues
+
+For a complete list of all known issues, see the list of link:https://issues.redhat.com/browse/WINDUP-3470?filter=12419394[MTR 1.2.0 known issues] in Jira.

--- a/docs/topics/mtr-rn-new-features-1-2-0.adoc
+++ b/docs/topics/mtr-rn-new-features-1-2-0.adoc
@@ -21,4 +21,4 @@ This section describes the new features of the {ProductName} ({ProductShortName}
 . Camel 4: Comprehensive rulesets supporting upgrade to all Y-stream releases of Camel 3 and Camel 4.
 . More migration rules to support Red Hat JBoss EAP 8 and Hibernate 6.
 // Edited the language. Please review if acceptable.
-. Java/Jakarta EE to Quarkus: New rulesets support migrating Java/Jakarta EE applications to Quarkus 3. These rulesets cover the _quarkification_ of the project, along with JAX-RS and CDI technologies. Additional rules that support this migration path are still under development and will be made available in future Z stream releases.
+. Java/Jakarta EE to Quarkus: New rulesets support migrating Java/Jakarta EE applications to Quarkus 3. These rulesets cover the _quarkification_ of the project, along with JAX-RS and CDI technologies. Additional rules that support this migration path are still under development and will be made available in future Z-stream releases.

--- a/docs/topics/mtr-rn-new-features-1-2-0.adoc
+++ b/docs/topics/mtr-rn-new-features-1-2-0.adoc
@@ -1,0 +1,12 @@
+// Module included in the following assemblies:
+//
+// * docs/release_notes/master.adoc
+
+:_content-type: CONCEPT
+[id="rn-new-features-1-2-0_{context}"]
+= New features
+
+This section describes the new features of the {ProductName} ({ProductShortName}) 1.0.1.
+
+.New ruleset for Jakarta Faces 4.0
+{ProductShortName} includes a new ruleset for Jakarta Faces 4.0 to improve support for migrating to JBoss EAP 8.

--- a/docs/topics/mtr-rn-new-features-1-2-0.adoc
+++ b/docs/topics/mtr-rn-new-features-1-2-0.adoc
@@ -6,7 +6,17 @@
 [id="rn-new-features-1-2-0_{context}"]
 = New features
 
-This section describes the new features of the {ProductName} ({ProductShortName}) 1.0.1.
+This section describes the new features of the {ProductName} ({ProductShortName}) 1.2.0.
 
-.New ruleset for Jakarta Faces 4.0
-{ProductShortName} includes a new ruleset for Jakarta Faces 4.0 to improve support for migrating to JBoss EAP 8.
+. Decompile and analyze Java 17 based applications
+. Rules Override enhancement: introduced a further degree of selectivity so that a rule will only be overridden if `rulesetId` and `ruleId` match and the target of the override ruleset matches the target provided for the analysis
+. Eclipse Plugin Java 17 compatibility
+. Upgrade of the Windup Operator: it adopted `Quarkus 2.13.7.Final` and the `Quarkus Operator SDK 4.0.8`
+
+[id="rn-new-rulesets-targets-1-2-0"]
+== New rulesets and targets
+
+. Java/Jakarta EE to Quarkus: New rules and recipes to support this migration path to Quarkus 3
+. More migration rules to support Red Hat JBoss EAP 8, Hibernate 6, and Red Hat JBoss EAP XP5
+. Red Hat Java Web Server 6: support the upgrade of JWS / Tomcat applications to JWS 6 / Tomcat 10
+. Camel 4: Comprehensive rulesets supporting upgrade to all Y stream releases of Camel 3 and to Camel 4

--- a/docs/topics/mtr-rn-new-features-1-2-0.adoc
+++ b/docs/topics/mtr-rn-new-features-1-2-0.adoc
@@ -9,14 +9,16 @@
 This section describes the new features of the {ProductName} ({ProductShortName}) 1.2.0.
 
 . Decompile and analyze Java 17 based applications
-. Rules Override enhancement: introduced a further degree of selectivity so that a rule will only be overridden if `rulesetId` and `ruleId` match and the target of the override ruleset matches the target provided for the analysis
+. Rules Override enhancement: New degree of selectivity that only overrides a rule if `rulesetId` and `ruleId` match, and the target of the override ruleset matches the target provided for the analysis
 . Eclipse Plugin Java 17 compatibility
-. Upgrade of the Windup Operator: it adopted `Quarkus 2.13.7.Final` and the `Quarkus Operator SDK 4.0.8`
+. Upgrade of the Windup Operator: Adopted `Quarkus 2.13.7.Final` and the `Quarkus Operator SDK 4.0.8`
 
 [id="rn-new-rulesets-targets-1-2-0"]
 == New rulesets and targets
 
-. Java/Jakarta EE to Quarkus: New rules and recipes to support this migration path to Quarkus 3
-. More migration rules to support Red Hat JBoss EAP 8, Hibernate 6, and Red Hat JBoss EAP XP5
-. Red Hat Java Web Server 6: support the upgrade of JWS / Tomcat applications to JWS 6 / Tomcat 10
-. Camel 4: Comprehensive rulesets supporting upgrade to all Y stream releases of Camel 3 and to Camel 4
+. OpenJDK 21: Rules to support the upgrading to OpenJDK 21.
+. Red Hat JBoss Web Server 6: Rules to support the upgrade of JWS / Tomcat applications to JWS 6 / Tomcat 10.
+. Camel 4: Comprehensive rulesets supporting upgrade to all Y stream releases of Camel 3 and Camel 4.
+. More migration rules to support Red Hat JBoss EAP 8 and Hibernate 6.
+// Edited the language. Please review if acceptable.
+. Java/Jakarta EE to Quarkus: New rulesets support migrating Java/Jakarta EE applications to Quarkus 3. These rulesets cover the _quarkifcation_ of the project, along with JAX-RS and CDI technologies. Additional rules that support this migration path are still under development and will be made available in future Z stream releases.

--- a/docs/topics/mtr-rn-new-features-1-2-0.adoc
+++ b/docs/topics/mtr-rn-new-features-1-2-0.adoc
@@ -8,8 +8,8 @@
 
 This section describes the new features of the {ProductName} ({ProductShortName}) 1.2.0.
 
-. Decompile and analyze Java 17 based applications
-. Rules Override enhancement: New degree of selectivity that only overrides a rule if `rulesetId` and `ruleId` match, and the target of the override ruleset matches the target provided for the analysis
+. Decompilation and analysis of applications based on Java 17
+. Rules Override enhancement: A new condition has been added for overriding an existing rule. In addition to matching `rulesetId` and `ruleId`, the target technology in the override ruleset must match one of the targets that the user specified for running the analysis.
 . Eclipse Plugin Java 17 compatibility
 . Upgrade of the Windup Operator: Adopted `Quarkus 2.13.7.Final` and the `Quarkus Operator SDK 4.0.8`
 
@@ -17,8 +17,8 @@ This section describes the new features of the {ProductName} ({ProductShortName}
 == New rulesets and targets
 
 . OpenJDK 21: Rules to support the upgrading to OpenJDK 21.
-. Red Hat JBoss Web Server 6: Rules to support the upgrade of JWS / Tomcat applications to JWS 6 / Tomcat 10.
-. Camel 4: Comprehensive rulesets supporting upgrade to all Y stream releases of Camel 3 and Camel 4.
+. Red Hat JBoss Web Server 6: Rules to support the upgrade of JWS and Tomcat applications to JWS 6 and Tomcat 10. 
+. Camel 4: Comprehensive rulesets supporting upgrade to all Y-stream releases of Camel 3 and Camel 4.
 . More migration rules to support Red Hat JBoss EAP 8 and Hibernate 6.
 // Edited the language. Please review if acceptable.
-. Java/Jakarta EE to Quarkus: New rulesets support migrating Java/Jakarta EE applications to Quarkus 3. These rulesets cover the _quarkifcation_ of the project, along with JAX-RS and CDI technologies. Additional rules that support this migration path are still under development and will be made available in future Z stream releases.
+. Java/Jakarta EE to Quarkus: New rulesets support migrating Java/Jakarta EE applications to Quarkus 3. These rulesets cover the _quarkification_ of the project, along with JAX-RS and CDI technologies. Additional rules that support this migration path are still under development and will be made available in future Z stream releases.

--- a/docs/topics/mtr-rn-resolved-issues-1-2-0.adoc
+++ b/docs/topics/mtr-rn-resolved-issues-1-2-0.adoc
@@ -6,4 +6,4 @@
 [id="mtr-rn-resolved-issues-1-2-0_{context}"]
 = Resolved issues
 
-For a complete list of all issues resolved in this release, see the list of link:https://issues.redhat.com/browse/WINDUP-3632?filter=12419395[{ProductShortName} 1.2.0 resolved issues] in Jira.
+For a complete list of all issues resolved in this release, see the list of link:https://issues.redhat.com/browse/WINDUP-3632?filter=12419395[MTR 1.2.0 resolved issues] in Jira.

--- a/docs/topics/mtr-rn-resolved-issues-1-2-0.adoc
+++ b/docs/topics/mtr-rn-resolved-issues-1-2-0.adoc
@@ -1,0 +1,9 @@
+// Module included in the following assemblies:
+//
+// * docs/release-notes-mtr/mtr_release_notes-1.0/master.adoc
+
+:_content-type: REFERENCE
+[id="mtr-rn-resolved-issues-1-2-0_{context}"]
+= Resolved issues
+
+For a complete list of all issues resolved in this release, see the list of link:https://issues.redhat.com/browse/WINDUP-3632?filter=12419395[{ProductShortName} 1.2.0 resolved issues] in Jira.


### PR DESCRIPTION
[Windup-3997](https://issues.redhat.com/browse/WINDUP-3997)

[PREVIEW](https://deploy-preview-746--windup-documentation.netlify.app/docs/release-notes-mtr/master/)

I have reverted the erroneous commit in Hagay's PR (see [Hagay's PR)](https://github.com/windup/windup-documentation/pull/736).

I think Phil likes to include earlier releases in his JIRA filter for known issue. It is consistent with filters he has provided previously.