### PR TITLE
Windup-4036: MTR remove Red Hat CodeReady Studio references

### DIFF
--- a/docs/eclipse-code-ready-studio-guide-mtr/master.adoc
+++ b/docs/eclipse-code-ready-studio-guide-mtr/master.adoc
@@ -8,12 +8,12 @@ include::topics/templates/document-attributes.adoc[]
 :context: eclipse-code-ready-studio-guide
 :eclipse-code-ready-studio-guide:
 :AddonType: plugin
-:IDEName: Eclipse and Red Hat CodeReady Studio
+:IDEName: Eclipse
 :mtr:
 include::topics/templates/document-attributes.adoc[]
 :_content-type: ASSEMBLY
 [id="eclipse-code-ready-studio-guide"]
-= Eclipse and Red Hat CodeReady Studio Guide
+= Eclipse Guide
 
 //Inclusive language statement
 include::topics/making-open-source-more-inclusive.adoc[]

--- a/docs/topics/about-tools.adoc
+++ b/docs/topics/about-tools.adoc
@@ -19,7 +19,7 @@ endif::[]
 * {ProductName} Operator
 * CLI
 * IDE addons for:
-** Eclipse and Red Hat CodeReady Studio
+** Eclipse
 ** Visual Studio Code, Visual Studio Codespaces, and Eclipse Che
 ** IntelliJ IDEA
 * {MavenName}

--- a/docs/topics/eclipse-about-plugin.adoc
+++ b/docs/topics/eclipse-about-plugin.adoc
@@ -5,9 +5,9 @@
 
 :_content-type: CONCEPT
 [id="eclipse-about-plugin_{context}"]
-= About the {PluginName} for Eclipse and Red Hat CodeReady Studio
+= About the {PluginName} for Eclipse
 
-The {ProductName} ({ProductShortName}) plugin for Eclipse and Red Hat CodeReady Studio helps you migrate and modernize applications.
+The {ProductName} ({ProductShortName}) plugin for Eclipse helps you migrate and modernize applications.
 
 The {PluginName} analyzes your projects using customizable rulesets, marks migration issues in the source code, provides guidance to fix the issues, and offers automatic code replacement, or Quick Fixes, if possible.
 

--- a/docs/topics/eclipse-accessing-tools.adoc
+++ b/docs/topics/eclipse-accessing-tools.adoc
@@ -10,7 +10,7 @@ You can access the {PluginName} tools in the *{ProductShortName}* perspective.
 
 .Prerequisites
 
-* You must restart the Eclipse IDE or Red Hat CodeReady Studio after installing the {PluginName}.
+* You must restart the Eclipse IDE after installing the {PluginName}.
 
 .Procedure
 

--- a/docs/topics/eclipse-configuring-run.adoc
+++ b/docs/topics/eclipse-configuring-run.adoc
@@ -12,7 +12,7 @@ You can create multiple run configurations. Each run configuration must have a u
 
 .Prerequisite
 
-* You must import your projects into the Eclipse IDE or CodeReady Studio.
+* You must import your projects into the Eclipse IDE.
 
 .Procedure
 

--- a/docs/topics/eclipse-installing-plugin.adoc
+++ b/docs/topics/eclipse-installing-plugin.adoc
@@ -9,7 +9,7 @@
 
 You need a connected environment to install the {PluginName}.
 
-The {PluginName} has been tested with the Eclipse IDE for Java Enterprise Developers 2022-03 and Red Hat CodeReady Studio 12.21.3.GA.
+The {PluginName} has been tested with the Eclipse IDE for Java Enterprise Developers 2022-03.
 
 .Prerequisites
 
@@ -23,13 +23,13 @@ The {PluginName} has been tested with the Eclipse IDE for Java Enterprise Develo
 * 8 GB RAM
 * macOS installation: the value of `maxproc` must be `2048` or greater.
 
-* link:{CodeReadyStudioDownloadPageURL}[Red Hat CodeReady Studio] _or_ link:https://www.eclipse.org/downloads/packages/release/2022-03/r/eclipse-ide-java-developers[Eclipse IDE for Java Enterprise Developers 2022-03]
+* link:https://www.eclipse.org/downloads/packages/release/2022-03/r/eclipse-ide-java-developers[Eclipse IDE for Java Enterprise Developers 2022-03]
 * JBoss Tools, installed from the link:https://marketplace.eclipse.org/content/jboss-tools[Eclipse Marketplace]
 * link:http://download.eclipse.org/mylyn/releases/latest[Mylyn SDK and frameworks], installed with Eclipse
 
 .Procedure
 
-. Launch Eclipse or CodeReady Studio.
+. Launch Eclipse.
 . From the menu bar, select *Help* -> *Install New Software*.
 . Next to the *Work with* field, click *Add*.
 . In the *Name* field, enter `{ProductShortName}`.
@@ -43,4 +43,4 @@ endif::[]
 . Select all the *JBoss Tools - {ProductShortName}* check boxes and click *Next*.
 . Review the installation details and click *Next*.
 . Accept the terms of the license agreement and click *Finish*.
-. Restart Eclipse or CodeReady Studio.
+. Restart Eclipse.

--- a/docs/topics/getting-started-about-ide-addons.adoc
+++ b/docs/topics/getting-started-about-ide-addons.adoc
@@ -9,7 +9,7 @@
 
 You can migrate and modernize applications by using the {ProductName} ({ProductShortName}) addons for:
 
-* Eclipse and Red Hat CodeReady Studio
+* Eclipse
 * Visual Studio Code, Visual Studio Codespaces, and Eclipse Che
 * IntelliJ IDEA, both the Community and Ultimate versions
 

--- a/docs/topics/method-deploy.adoc
+++ b/docs/topics/method-deploy.adoc
@@ -13,4 +13,4 @@ The _Deploy_ phase is when you run the plan created in the Design phase. In this
 
 The plan is run in iterations to deliver value incrementally. With each iteration, you continuously validate against the plan and document findings to improve the next sprint.
 
-The use of the {ProductName} {PluginName} increases speed in each iteration. It can be used with Eclipse or Red Hat CodeReady Studio, and marks migration issues directly in the source code, provides inline hints, and offers code change suggestions. See the link:{EclipseCrsGuideURL}[_{EclipseCrsGuideTitle}_] for information on how to use the {PluginName}.
+The use of the {ProductName} {PluginName} increases speed in each iteration. It can be used with Eclipse, and marks migration issues directly in the source code, provides inline hints, and offers code change suggestions. See the link:{EclipseCrsGuideURL}[_{EclipseCrsGuideTitle}_] for information on how to use the {PluginName}.

--- a/docs/topics/plugin-intro.adoc
+++ b/docs/topics/plugin-intro.adoc
@@ -9,5 +9,5 @@
 This guide is for engineers, consultants, and others who want to use the {PluginName} for the {ProductName} ({ProductShortName}) to assist with migrating applications.
 
 ifndef::vscode-plugin-guide[]
-NOTE: This guide uses _Eclipse_ to refer to an installation of Eclipse or Red Hat CodeReady Studio.
+// NOTE: This guide uses _Eclipse_ to refer to an installation of Eclipse.
 endif::[]

--- a/docs/topics/rules-testing-junit.adoc
+++ b/docs/topics/rules-testing-junit.adoc
@@ -15,7 +15,7 @@ Once a test rule has been created, it can be analyzed as part of a JUnit test to
 
 .Creating the JUnit test configuration
 
-The following instructions detail creating a JUnit test using the Red Hat CodeReady Studio. When using a different IDE it is recommended to consult your IDE's documentation for instructions on creating a JUnit test.
+The following instructions detail creating a JUnit test using Eclipsex. When using a different IDE it is recommended to consult your IDE's documentation for instructions on creating a JUnit test.
 
 . Import the {ProductShortName} rulesets repository into your IDE.
 . Copy the custom rules, along with the corresponding tests and data, into `</path/to/RULESETS_REPO>/rules-reviewed/<RULE_NAME>/`. This should create the following directory structure.

--- a/index.md
+++ b/index.md
@@ -20,7 +20,7 @@ Migration Toolkit for Runtimes
 - [CLI Guide](docs/cli-guide-mtr/master/index.html)
 - [Rules Development Guide](docs/rules-development-guide-mtr/master/index.html)
 - [Maven Plugin Guide](docs/maven-guide-mtr/master/index.html)
-- [Eclipse and Red Hat CodeReady Studio Guide](docs/eclipse-code-ready-studio-guide-mtr/master/index.html)
+- [Eclipse Plugin Guide](docs/eclipse-code-ready-studio-guide-mtr/master/index.html)
 - [IntelliJ IDEA Plugin Guide](docs/intellij-idea-plugin-guide-mtr/master/index.html)
 - [Release Notes](docs/release-notes-mtr/master/index.html)
 - [Visual Studio Code Extension Guide](docs/vs-code-extension-guide-mtr/master/index.html)


### PR DESCRIPTION
Updating [Hagay's PR](https://github.com/windup/windup-documentation/pull/744)

Changing index.md for MTR to change the title to Eclipse Plugin Guide