### PR TITLE
MTA-1180: Release notes for v7.0.0

### DIFF
--- a/docs/release-notes/master.adoc
+++ b/docs/release-notes/master.adoc
@@ -17,21 +17,17 @@ include::topics/making-open-source-more-inclusive.adoc[]
 == Introduction
 {ProductName} {DocInfoProductNumber} accelerates large-scale application modernization efforts across hybrid cloud environments on Red Hat OpenShift. This solution provides insight throughout the adoption process, at both the portfolio and application levels: inventory, assess, analyze, and manage applications for faster migration to OpenShift via the user interface.
 
-These release notes cover all _z_-stream releases of {ProductShortName} 6.2 with the most recent release listed first.
+[id="mta-7-0-0"]
+== {ProductShortName} 7-0-0
 
-[id="mta-6-2-1"]
-== {ProductShortName} 6.2.1
+include::topics/mta-rn-new-features-7-0-0.adoc[leveloffset=+2]
 
-include::topics/mta-rn-resolved-issues-6-2-1.adoc[leveloffset=+2]
+include::topics/mta-rn-known-issues-7-0-0.adoc[leveloffset=+2]
 
-[id="mta-6-2-0"]
-== {ProductShortName} 6.2.0
+include::topics/mta-rn-resolved-issues-7-0-0.adoc[leveloffset=+2]
 
-include::topics/mta-rn-new-features-6-2-0.adoc[leveloffset=+2]
+include::topics/mta-rn-upgrade-notes-7-0-0.adoc[leveloffset=+2]
 
-include::topics/mta-rn-known-issues-6-2-0.adoc[leveloffset=+2]
-
-include::topics/mta-rn-resolved-issues-6-2-0.adoc[leveloffset=+2]
-
+include::topics/mta-rn-technical-changes-7-0-0.adoc[leveloffset=+2]
 
 :!release-notes:

--- a/docs/topics/mta-rn-known-issues-7-0-0.adoc
+++ b/docs/topics/mta-rn-known-issues-7-0-0.adoc
@@ -1,0 +1,36 @@
+// Module included in the following assemblies:
+//
+// * docs/release_notes/master.adoc
+
+:_content-type: REFERENCE
+[id="rn-known-issues-7-0-0_{context}"]
+= Known issues
+
+[ProductFullName] version 7.0.0 has the following issues.
+
+.Delayed permission update and user deactivation in `RBAC`
+
+When deleting, deactivating or degrading the role of a user, such as changing the user from `Admin` to `Migrator`, the change can take several minutes to take effect. This delay in changing the user status can pose an operational or security risk. link:https://issues.redhat.com/browse/MTA-1809[MTA-1809]
+
+.Re-enabling Keycloak breaks MTA
+  
+Keycloak is enabled by default. If you disable and then re-enable Keycloak, you cannot perform any actions in the MTA web console after logging in again.
+
+This error is caused as the `credential-mta-rhsso` secret is updated when `auth/Keycloak` is disabled and re-enabled.
+  
+The suggested workaround is to restore the old password in the `credential-mta-rhsso` secret, after re-enabling `auth`. link:https://issues.redhat.com/browse/MTA-1152[MTA-1152]
+
+
+.org.apache.derby.derby dependency not analyzed
+
+The `org.apache.derby.derby` dependency is not analyzed. link:https://issues.redhat.com/browse/MTA-1817[MTA-1817]
+
+.Redundant warning on reassessment of applications with inherited assessments
+
+The system repeatedly shows a warning message about overriding an inherited assessment when reassessing an application.
+
+This warning, appropriate for the first assessment, incorrectly reappears on subsequent reassessments, suggesting that the application is still inheriting its assessment, even after it has been overridden. link:https://issues.redhat.com/browse/MTA-1825[MTA-1825]
+
+For a complete list of all known issues in this release, see the list of link:https://issues.redhat.com/browse/MTA-2060?filter=12428334[Known Issues in Jira].
+
+// using filter - project in (MTA) AND type = Bug AND createdDate >= 2021-01-01 AND createdDate <= 2024-01-30 AND (resolutiondate > 2024-01-30 OR resolutiondate is EMPTY) AND Priority in (Blocker, Critical, Major) ORDER BY priority DESC, key DESC

--- a/docs/topics/mta-rn-known-issues-7-0-0.adoc
+++ b/docs/topics/mta-rn-known-issues-7-0-0.adoc
@@ -10,7 +10,7 @@
 
 .Pathfinder assessment migration fails on upgrade from {ProductShortName} 6.2.1 to {ProductShortName} 7.0.0
 
-If {ProductShortName} 6.2.1 is installed, when attempting to switch the channel to `stable-7.0`, the operator upgrade succeeds, but a task in the operator pod fails. This failure results in existing pathfinder assessments not being migrated to {ProductShortName} 7.0.0. This bug will be resolved in 7.0.1. No assessment data will be lost, it is will simply not be visible in the UI until the release of {ProductShortName} 7.0.1. link:https://issues.redhat.com/browse/MTA-2139[MTA-2139]
+If {ProductShortName} 6.2.1 is installed, when attempting to switch the channel to `stable-7.0`, the operator upgrade succeeds, but a task in the operator pod fails. This failure results in existing pathfinder assessments not being migrated to {ProductShortName} 7.0.0. This bug will be resolved in {ProductShortName} 7.0.1. No assessment data will be lost, it is will simply not be visible in the UI until the release of {ProductShortName} 7.0.1. link:https://issues.redhat.com/browse/MTA-2139[MTA-2139]
 
 .Delayed permission update and user deactivation in `RBAC`
 

--- a/docs/topics/mta-rn-known-issues-7-0-0.adoc
+++ b/docs/topics/mta-rn-known-issues-7-0-0.adoc
@@ -8,17 +8,17 @@
 
 [ProductFullName] version 7.0.0 has the following issues.
 
-.Pathfinder assessment migration fails on upgrade from MTA 6.2.1 to MTA 7.0.0
+.Pathfinder assessment migration fails on upgrade from {ProductShortName} 6.2.1 to {ProductShortName} 7.0.0
 
-If MTA 6.2.1 is installed, when attempting to switch the channel to `stable-7.0`, the operator upgrade succeeds, but a task in the operator pod fails. This failure results in existing pathfinder assessments not being migrated to MTA 7.0.0. link:https://issues.redhat.com/browse/MTA-2139[MTA-2139]
+If {ProductShortName} 6.2.1 is installed, when attempting to switch the channel to `stable-7.0`, the operator upgrade succeeds, but a task in the operator pod fails. This failure results in existing pathfinder assessments not being migrated to {ProductShortName} 7.0.0. This bug will be resolved in 7.0.1. No assessment data will be lost, it is will simply not be visible in the UI until the release of {ProductShortName} 7.0.1. link:https://issues.redhat.com/browse/MTA-2139[MTA-2139]
 
 .Delayed permission update and user deactivation in `RBAC`
 
 When deleting, deactivating or degrading the role of a user, such as changing the user from `Admin` to `Migrator`, the change can take several minutes to take effect. This delay in changing the user status can pose an operational or security risk. link:https://issues.redhat.com/browse/MTA-1809[MTA-1809]
 
-.Re-enabling Keycloak breaks MTA
+.Re-enabling Keycloak breaks {ProductShortName}
   
-Keycloak is enabled by default. If you disable and then re-enable Keycloak, you cannot perform any actions in the MTA web console after logging in again.
+Keycloak is enabled by default. If you disable and then re-enable Keycloak, you cannot perform any actions in the {ProductShortName} web console after logging in again.
 
 This error is caused as the `credential-mta-rhsso` secret is updated when `auth/Keycloak` is disabled and re-enabled.
   

--- a/docs/topics/mta-rn-known-issues-7-0-0.adoc
+++ b/docs/topics/mta-rn-known-issues-7-0-0.adoc
@@ -8,6 +8,10 @@
 
 [ProductFullName] version 7.0.0 has the following issues.
 
+.Pathfinder assessment migration fails on upgrade from MTA 6.2.1 to MTA 7.0.0
+
+If MTA 6.2.1 is installed, when attempting to switch the channel to `stable-7.0`, the operator upgrade succeeds, but a task in the operator pod fails. This failure results in existing pathfinder assessments not being migrated to MTA 7.0.0. link:https://issues.redhat.com/browse/MTA-2139[MTA-2139]
+
 .Delayed permission update and user deactivation in `RBAC`
 
 When deleting, deactivating or degrading the role of a user, such as changing the user from `Admin` to `Migrator`, the change can take several minutes to take effect. This delay in changing the user status can pose an operational or security risk. link:https://issues.redhat.com/browse/MTA-1809[MTA-1809]

--- a/docs/topics/mta-rn-known-issues.adoc
+++ b/docs/topics/mta-rn-known-issues.adoc
@@ -1,9 +1,0 @@
-// Module included in the following assemblies:
-//
-// * docs/release_notes/master.adoc
-
-:_content-type: REFERENCE
-[id="rn-known-issues_{context}"]
-= Known issues
-
-At the time of release, there are no known issues in this release.

--- a/docs/topics/mta-rn-new-features-7-0-0.adoc
+++ b/docs/topics/mta-rn-new-features-7-0-0.adoc
@@ -1,0 +1,53 @@
+// Module included in the following assemblies:
+//
+// * docs/release_notes/master.adoc
+
+:_content-type: CONCEPT
+[id="rn-new-features-7-0-0_{context}"]
+= New features
+
+
+This section describes the new features and improvements of the {ProductFullName} 7.0.0.
+
+
+.Enhanced assessment module with custom questionnaire
+
+In {ProductShortName} 7.0.0, the assessment module has been enhanced. The assessment module in this release allows you to import questionnaires using a custom YAML syntax for questionnaire definition.
+
+// add xref
+
+.Grouping applications for assessment into archetypes
+
+In {ProductShortName} 7.0.0, you can assess and analyze entire groups of applications or *archetypes*, according to common characteristics.
+
+Application *archetypes* are defined according to criteria tags and application taxonomy. Each archetype selects how the applications are assessed according to its characteristics.
+
+For more details, see xref:mta-web-archetypes.adoc[Application archetypes].
+
+
+.Unlink applications from JIRA
+
+In {ProductShortName} 7.0.0, you now have the ability to unlink an application from a Jira ticket, so that you can manage the links between applications and tickets more effectively. To unlink an application from a Jira ticket, click the `Unlink from Jira` icon in the details view of the application or in the details view of a Migration wave.
+
+// For more details, see xref:mta-web-creating-jira-issues-for-migration-wave.adoc#[Unlink applications from JIRA option].
+
+.YAML syntax for new rules
+
+New rules that use YAML syntax to support metadata, `message` and `tag` actions, rule conditions, provider conditions for *Java* and *Go* providers, and other file tagging and characteristics.
+
+
+.Dynamic reports
+
+{ProductShortName} 7.0.0 produces dynamic analysis reports that collect aggregated issues and dependencies across the application portfolio. They identify portfolio-wide trends, drill down to specific lines in source code, and fully integrate with {ProductShortName} User Interface (UI).
+
+.Multi-language analysis
+
+{ProductShortName} 7.0.0 supports migrating applications written in Java and Golang implemented in Language Server Protocol (LSP).
+
+:FeatureName: Multi-language analysis for Golang
+include::technology-preview.adoc[]
+
+
+
+
+

--- a/docs/topics/mta-rn-new-features-7-0-0.adoc
+++ b/docs/topics/mta-rn-new-features-7-0-0.adoc
@@ -22,7 +22,7 @@ In {ProductShortName} 7.0.0, you can assess and analyze entire groups of applica
 
 Application *archetypes* are defined according to criteria tags and application taxonomy. Each archetype selects how the applications are assessed according to its characteristics.
 
-For more details, see xref:mta-web-archetypes.adoc[Application archetypes].
+// For more details, see xref:mta-web-archetypes.adoc[Application archetypes].
 
 
 .Unlink applications from JIRA

--- a/docs/topics/mta-rn-resolved-issues-7-0-0.adoc
+++ b/docs/topics/mta-rn-resolved-issues-7-0-0.adoc
@@ -1,0 +1,27 @@
+// Module included in the following assemblies:
+//
+// * docs/release_notes-7.0/master.adoc
+
+:_content-type: REFERENCE
+[id="mta-rn-resolved-issues-7-0-0_{context}"]
+= Resolved issues
+
+The following highlighted issues have been resolved in {ProductFullName} version 7.0.0.
+
+.No update notification after editing fields
+
+In previous versions of {ProductShortName}, no `Update Notification` appeared at top of window after the fields `Application`, `Job Function`, and `Business services` were updated. This issue has been resolved in {ProductShortName}.  link:https://issues.redhat.com/browse/MTA-1024[MTA-1024]
+
+.Not possible to create a Jira instance behind a proxy
+
+In previous versions of {ProductShortName}, it was not possible to create a Jira instance (issues.stage.redhat.com) behind a proxy. This issue has been resolved in {ProductShortName}. link:https://issues.redhat.com/browse/MTA-849[MTA-849]
+
+// think we are safe to move this
+.CVE-2023-6291: A flaw was found in the `redirect_uri validation` logic
+
+A flaw was found in the `redirect_uri validation` logic that allows for a bypass of otherwise explicitly allowed hosts. The problem arises in the `verifyRedirectUri` method, which attempts to enforce rules on `user-controllable` input, but can cause a desynchronization in how Keycloak and browsers interpret URLs.
+
+For more details, see link:https://access.redhat.com/security/cve/cve-2023-6291[(CVE-2023-6291)].
+
+For a complete list of all issues resolved in this release, see the list of link:https://issues.redhat.com/issues/?filter=12420807[Resolved Issues in Jira].
+

--- a/docs/topics/mta-rn-technical-changes-7-0-0.adoc
+++ b/docs/topics/mta-rn-technical-changes-7-0-0.adoc
@@ -1,0 +1,76 @@
+// Module included in the following assemblies:
+//
+// * docs/release_notes-7.0/master.adoc
+
+:_content-type: REFERENCE
+[id="mta-rn-technical-changes-7-0-0_{context}"]
+= Technical changes
+
+The following technical changes have been made in {ProductFullName} 7.0.0:
+
+* The Maven Plugin has been deprecated.
+
+* Language Server Protocol (LSP) Analyzer change.
+
+[id="mta-rn-technical-changes-rules-7-0-0_{context}"]
+== Rules
+
+.Rules can only be written in YAML
+
+Rules written in Groovy and Java are discontinued in {ProductShortName} version 7.0.0. Some of the previous Groovy Java rules have been converted to YAML rules wherever possible.
+
+An important modification to the rule's engine is that it is no longer possible to query anything apart from the tags stored within the engine's internal data structures. This means that all the features that were enabled by using the `graph-query` element in the rule are no longer available.
+
+.Java Class child elements not supported in {ProductShortName}
+
+The Java Class child elements `annotation-list`, `annotation-type` and `annotation-literal` are not supported in {ProductShortName} version 7.0.0.
+
+.Elements <project> and <dependency> are merged into one dependency condition
+
+The capabilities of <project> and <dependency> elements in the old syntax are merged into one dependency condition in the new rules syntax.
+
+.Transformation capabilities of `xslt` element are discontinued
+
+XML transformation capabilities offered by the `xslt` element are discontinued.
+
+.Explicit `iteration` element is discontinued
+
+The explicit `iteration` element is discontinued in {ProductShortName} version 7.0.0.. If a condition returns a list of items via the `as` construct, iteration is implied.
+
+.Test rules not supported in the current version
+
+Test rules are not supported in {ProductShortName} version 7.0.0.
+
+.Overriding a rule discontinued
+
+Overriding a rule is discontinued in {ProductShortName} version 7.0.0.
+
+.Creating custom rule categories discontinued
+
+Creating custom rule categories is discontinued in {ProductShortName} version 7.0.0.
+
+.Information and optional categories of rules are discontinued.
+
+In {ProductShortName} version 7.0.0, any previous rules of information and optional categories will only create technology tags.
+
+.Java analysis capabilities
+
+In {ProductShortName} version 7.0.0, the following Java analysis capabilities have been deprecated: 
+
+* Ability to match on specific arguments of a Java method constructor is not supported in the current version
+
+* Matching Java references from JavaServer Pages (JSP) files are not supported in the current version
+
+* `Mavenizing` a Java project, meaning write a POM and possibly move code around so that it builds in Maven, is discontinued.
+
+.Analysis report changes
+
+The following functionality in Analysis reports has been deprecated:
+
+* Story points are shown as integers. The “level of effort” view and their mappings are deprecated in {ProductShortName} version 7.0.0.
+
+* Transactions reports are deprecated in {ProductShortName} version 7.0.0.
+
+* The view for “Archives shared by multiple applications” is deprecated in {ProductShortName} version 7.0.0.
+
+* The view for “Review rule providers execution overview” deprecated in {ProductShortName} version 7.0.0.

--- a/docs/topics/mta-rn-upgrade-notes-7-0-0.adoc
+++ b/docs/topics/mta-rn-upgrade-notes-7-0-0.adoc
@@ -1,0 +1,39 @@
+// Module included in the following assemblies:
+//
+// * docs/release_notes-7.0/master.adoc
+
+:_content-type: REFERENCE
+[id="mta-rn-upgrade-notes-7-0-0_{context}"]
+= Upgrade notes
+
+The following are upgrade notes for {ProductFullName}
+
+.Hub database volume size
+
+In version 7.0.0 of {ProductShortName}, the default size of the hub database volume has been increased to 10GiB.
+
+If your storage class does not support volume expansion, then an upgrade from 6.2.1 to 7.0.0 will result in a failure due to the operator trying to change the volume size from 5GiB to 10G.
+
+To avoid this issue, you can directly set the volume size by setting:
+
+// the example said 5Gi but should it be 10Gi
+[source,yaml]
+----
+...
+hub_database_volume_size: 10Gi
+...
+----
+
+By doing this, you will avoid the operator trying to resize the volume.
+
+
+.Existing data
+
+When upgrading to {ProductShortName} 7.0.0, all existing data will be retained, except for individual analysis reports for applications.
+
+As both the analysis and reporting engines have been replaced with this version, you will be required to conduct a re-run of the analysis in order to obtain data on issues and dependencies.
+
+
+.Version upgrade
+
+You can upgrade to {ProductShortName} 7.0.0 from 6.2.1. It is not recommended to pursue any alternative upgrade route. If you wish to upgrade from a previous version, it is recommended to proceed in a sequential manner until you finally upgrade from {ProductShortName} version 6.2.1 to 7.0.0.

--- a/docs/topics/technology-preview.adoc
+++ b/docs/topics/technology-preview.adoc
@@ -1,0 +1,12 @@
+// When including this file, ensure that {FeatureName} is set immediately before
+// the include. Otherwise it will result in an incorrect replacement.
+
+[IMPORTANT]
+====
+[subs="attributes+"]
+{FeatureName} is a Technology Preview feature only. Technology Preview features are not supported with Red Hat production service level agreements (SLAs) and might not be functionally complete. Red Hat does not recommend using them in production. These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process.
+
+For more information about the support scope of Red Hat Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope].
+====
+// Undefine {FeatureName} attribute, so that any mistakes are easily spotted
+:!FeatureName:


### PR DESCRIPTION
### Jira

* [MTA-1180](https://issues.redhat.com/browse/MTA-1180)

### Preview

* [MTA 7.0.0 release notes](https://deploy-preview-804--windup-documentation.netlify.app/docs/release-notes/master/#rn-new-features-7-0-0_release-notes)


#### Reviews from earlier PR

* There are two languages at this time . Java and Go out of which Go is Tech Preview only.
* The new feature list is missing :

   1. Enhanced assessment module with custom questionnaire
   2. Grouping applications for assessment into archetypes.
   3. Unlink applications from JIRA

* 


