### PR TITLE
MTA-2103  insert attributes instead of "windup" and "windup-cli"

### DIFF
--- a/docs/topics/configuring-web-console-authentication-for-linux-windows-macos.adoc
+++ b/docs/topics/configuring-web-console-authentication-for-linux-windows-macos.adoc
@@ -30,8 +30,8 @@ $ ./standalone.sh -Djboss.socket.binding.port-offset=<offset_value>
 . Open the Red Hat SSO administration console from `\http://localhost:8180`:
 * Username: `admin`
 * Password: `admin`
-. Add a realm named *windup*.
-. In the realm, create a client named *windup-web*.
+. Add a realm named *{LC_PSN}*.
+. In the realm, create a client named *{LC_PSN}-web*.
 . Check that *Access Type* is set to `public`.
 . Set *Valid Redirect URIs* to `\http://localhost:8080/windup-ui/*`.
 . Set *Web Origins* to `+*+` and click *Save*.

--- a/docs/topics/installing-web-console-on-openshift.adoc
+++ b/docs/topics/installing-web-console-on-openshift.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * docs/web-console-guide/master.adoc
+// * docs/web-console-guide-mtr/master.adoc
 
 :_content-type: PROCEDURE
 [id="installing-web-console-on-openshift_{context}"]

--- a/docs/topics/vs-code-extension-run-configuration.adoc
+++ b/docs/topics/vs-code-extension-run-configuration.adoc
@@ -10,7 +10,7 @@ You can configure multiple run configurations to run against each project you im
 
 .Prerequisites
 
-* `windup-cli` executable installed. You can download the `windup-cli` executable from link:{DevDownloadPageURL}[{LC_PSN} download].
+* `{mta-cli}` executable installed. You can download the `{mta-cli}` executable from link:{DevDownloadPageURL}[{LC_PSN} download].
 
 .Procedure
 
@@ -19,7 +19,7 @@ You can configure multiple run configurations to run against each project you im
 . Complete the following configuration fields:
 
 ** *Name*: Enter a meaningful name for the analysis configuration or accept the default.
-** *cli*: Enter the path to the cli executable. For example: `$HOME/{LC_PSN}-cli-{ProductDistributionVersion}/bin/windup-cli`.
+** *cli*: Enter the path to the cli executable. For example: `$HOME/{mta-cli}-{ProductDistributionVersion}/bin/{mta-cli}`.
 ** *Input*: Set to the path of the project that you have open within your IDE by clicking *Add* and doing one of the following:
 
 *** Enter the input file or directory and press Enter.


### PR DESCRIPTION
https://issues.redhat.com/browse/MTA-2103
Replace "windup" and "windup-cli" references with attributes  {LC_PSN} and {mta-cli}



https://docs.google.com/document/d/1W9FjPuCHQlStZXqiDCTZq66Bq_5EDoqrS2cQEqyJrB4/edit

Potential targets for update:

DONE /configuring-web-console-authentication-for-linux-windows-macos.adoc realm named windup , windup-web , SSO_REALM=windup , SSO_CLIENT_ID=windup-web

UNCHANGED (already contains some attributes) 
/exclude-files-and-packages.adoc .windup-ignore.txt

UNCHANGED - GITHUB addresses  /fork-ruleset-repo.adoc windup-rulesets repository

REVERTED CHANGES - belongs to MTR docs!  /installing-web-console-on-openshift.adoc realm named windup , client named windup-web

DONE in a separate PR   /mta-cli-transform.adoc windup-shim_

NOT FOUND    /plugin-install.adoc      Windup Feature , Windup Feature Developer Resources

UNCHANGED - GitHub addresses /review-quickstarts.adoc windup-quickstarts

UNCHANGED part of rules and repo addresses /rules-testing-junit.adoc WindupRulesMultipleTests , windup-rulesets

UNCHANGED part of Rules addresses  /testing-rules.adoc .widup.test.xml , proprietary-rule.windup.test.xml

UNCHANGED part of Rulesets path   /validation-report-understanding.adoc windup-rulesets repository

DONE    /vs-code-extension-run-configuration.adoc windup-cli

UNCHANGED part of Rulesets   /web-adding-custom-rules.adoc .windup.xml

UNCHANGED part of Rulesets   /web-adding-global-custom-labels.adoc .windup.label.xml

UNCHANGED part of Rulesets   /web-adding-global-custom-rules.adoc .windup.xml
