### PR TITLE
MTA 2066: remove Maven docs as Maven plugin deprecated

### DIFF
--- a/docs/getting-started-guide/master.adoc
+++ b/docs/getting-started-guide/master.adoc
@@ -55,7 +55,7 @@ include::topics/about-cli.adoc[leveloffset=+2]
 include::topics/getting-started-about-ide-addons.adoc[leveloffset=+2]
 
 // About the {MavenNameTitle}
-include::topics/about-maven.adoc[leveloffset=+2]
+// include::topics/about-maven.adoc[leveloffset=+2]
 
 [appendix]
 == Reference material

--- a/docs/maven-guide/master.adoc
+++ b/docs/maven-guide/master.adoc
@@ -10,6 +10,9 @@ include::topics/templates/document-attributes.adoc[]
 :_content-type: ASSEMBLY
 = Maven Plugin Guide
 
+The Maven plugin was deprecated in {ProductFullName} 7.0.0.
+////
+
 //Inclusive language statement
 include::topics/making-open-source-more-inclusive.adoc[]
 
@@ -72,3 +75,5 @@ include::topics/important-links.adoc[leveloffset=+3]
 include::topics/templates/revision-info.adoc[]
 
 :!maven-guide:
+
+////

--- a/index.md
+++ b/index.md
@@ -7,7 +7,7 @@ Migration Toolkit for Applications
 - [User Interface Guide](docs/web-console-guide/master/index.html)
 - [CLI Guide](docs/cli-guide/master/index.html)
 - [Rules Development Guide](docs/rules-development-guide/master/index.html)
-- [Maven Plugin Guide](docs/maven-guide/master/index.html)
+<!-- - [Maven Plugin Guide](docs/maven-guide/master/index.html) -->
 - [Eclipse Plugin Guide](docs/eclipse-code-ready-studio-guide/master/index.html)
 - [IntelliJ IDEA Plugin Guide](docs/intellij-idea-plugin-guide/master/index.html)
 - [Release Notes](docs/release-notes/master/index.html)


### PR DESCRIPTION
### Jira

* [MTA-2066](https://issues.redhat.com/browse/MTA-2066)

### Preview

* [Preview section showing Maven Plugin Guide removed](https://deploy-preview-812--windup-documentation.netlify.app/)