### PR TITLE
MTA-2161: VS Code screenshot is outdated

### DIFF
--- a/docs/topics/vs-code-extension-interface.adoc
+++ b/docs/topics/vs-code-extension-interface.adoc
@@ -17,7 +17,7 @@ The interface of the {ProductName} ({ProductShortName}) extension is designed to
 .{ProductShortName} extension interface
 
 ifdef::mta[]
-image::vs_code_extension_interface.png[{ProductShortName} extension interface]
+
 endif::[]
 
 ifdef::mtr[]


### PR DESCRIPTION
### JIRA

* [MTA-2161](https://issues.redhat.com/browse/MTA-2161)

### PREVIEW

* [3.1. MTA extension interface](https://deploy-preview-838--windup-documentation.netlify.app/docs/vs-code-extension-guide/master/#vs-code-extension-interface_vsc-extension-guide)

I have removed the screenshot, if I get time in the next few weeks, I come back and replace it. 