### PR TITLE
MTA-2288: Adding Custom Rule for Javax package to Known Issues

### DIFF
--- a/docs/topics/mta-rn-known-issues-7-0-0.adoc
+++ b/docs/topics/mta-rn-known-issues-7-0-0.adoc
@@ -41,8 +41,6 @@ In {ProductShortName} 7.0.0, some XML custom rule files are converted to the new
 
 To resolve this issue, whenever a custom rule has a pattern ending in `.{\*}` and location `IMPORT`, the pattern `.{*}` can be changed to `{*}` and the location changed to `PACKAGE`, as in the following example:.
 
-
-
 .To view the javax-package-custom-target.windup.xml, click here.
 [%collapsible%closed]
 ====

--- a/docs/topics/mta-rn-known-issues-7-0-0.adoc
+++ b/docs/topics/mta-rn-known-issues-7-0-0.adoc
@@ -39,7 +39,7 @@ This warning, appropriate for the first assessment, incorrectly reappears on sub
 
 In {ProductShortName} 7.0.0, some XML custom rule files are converted to the new YAML format during analysis. The root cause is that Java search patterns that use `IMPORT` as `location` and end in `.{*}`, do not function as expected. link:https://issues.redhat.com/browse/MTA-2000[MTA-2000]
 
-To resolve this issue, whenever a custom rule has a pattern ending in `.{\*}` and location `IMPORT`, the pattern `.{*}` can be changed to `{*}` and the location changed to `PACKAGE`, as in the following example:.
+To resolve this issue, whenever a custom rule has a pattern ending in `.{\*}` and location `IMPORT`, the pattern `.{*}` can be changed to `{*}` and the location changed to `PACKAGE`, as in the following example.
 
 .To view the javax-package-custom-target.windup.xml, click here.
 [%collapsible%closed]

--- a/docs/topics/mta-rn-known-issues-7-0-0.adoc
+++ b/docs/topics/mta-rn-known-issues-7-0-0.adoc
@@ -43,7 +43,6 @@ To resolve this issue, whenever a custom rule has a pattern ending in `.{\*}` an
 
 
 
-
 .To view the javax-package-custom-target.windup.xml, click here.
 [%collapsible%closed]
 ====

--- a/docs/topics/mta-rn-known-issues-7-0-0.adoc
+++ b/docs/topics/mta-rn-known-issues-7-0-0.adoc
@@ -37,7 +37,7 @@ This warning, appropriate for the first assessment, incorrectly reappears on sub
 
 .Custom rule for javax.{*} package import is not triggered when uploaded as an XML file
 
-In {ProductShortName} 7.0.0, some XML custom rule files are converted to the new YAML format during analysis. The root cause of this issue is Java search patterns that use `IMPORT` as `location`, should not end in `.{\*}` but `{\*}`. link:https://issues.redhat.com/browse/MTA-2000[MTA-2000]
+In {ProductShortName} 7.0.0, some XML custom rule files are converted to the new YAML format during analysis. The root cause of this issue is Java search patterns that use `IMPORT` as `location`, should not end in `.{\*}` but should end in `{*}`. link:https://issues.redhat.com/browse/MTA-2000[MTA-2000]
 
 To resolve this issue, whenever a custom rule has a pattern ending in `.{\*}` and location `IMPORT`, the pattern `.{*}` can be changed to `{*}` and the location changed to `PACKAGE`.
 

--- a/docs/topics/mta-rn-known-issues-7-0-0.adoc
+++ b/docs/topics/mta-rn-known-issues-7-0-0.adoc
@@ -39,7 +39,7 @@ This warning, appropriate for the first assessment, incorrectly reappears on sub
 
 In {ProductShortName} 7.0.0, some XML custom rule files are converted to the new YAML format during analysis. The root cause of this issue is Java search patterns that use `IMPORT` as `location`, should not end in `.{\*}` but should end in `{*}`. link:https://issues.redhat.com/browse/MTA-2000[MTA-2000]
 
-To resolve this issue, whenever a custom rule has a pattern ending in `.{\*}` and location `IMPORT`, the pattern `.{*}` can be changed to `{*}` and the location changed to `PACKAGE`.
+To resolve this issue, whenever a custom rule has a pattern ending in `.{\*}` and location `IMPORT`, the pattern `.{*}` can be changed to `{*}` and the location changed to `PACKAGE`, as in the following example:.
 
 In the following example XML rule, note that the `when` condition is `javaclass references ="javax.{*}"`. 
 

--- a/docs/topics/mta-rn-known-issues-7-0-0.adoc
+++ b/docs/topics/mta-rn-known-issues-7-0-0.adoc
@@ -87,9 +87,6 @@ If you amend this to `javaclass references="javax{*}"`, the rule converts correc
 The suggested workaround is to use the following YAML file instead. The YAML file is the result of a conversion from XML. 
 
 
-The file is the conversion result from XML to YAML format, with the line `location: IMPORT` was changed to `location: package`.
-
-
 For a complete list of all known issues in this release, see the list of link:https://issues.redhat.com/browse/MTA-2060?filter=12428334[Known Issues in Jira].
 
 // using filter - project in (MTA) AND type = Bug AND createdDate >= 2021-01-01 AND createdDate <= 2024-01-30 AND (resolutiondate > 2024-01-30 OR resolutiondate is EMPTY) AND Priority in (Blocker, Critical, Major) ORDER BY priority DESC, key DESC

--- a/docs/topics/mta-rn-known-issues-7-0-0.adoc
+++ b/docs/topics/mta-rn-known-issues-7-0-0.adoc
@@ -79,7 +79,7 @@ For example, when using `javax-package-custom-target.windup.xml` as a custom rul
 ----
 ====
 
-The suggested workaround is to convert the XML file to a YAML file
+The suggested workaround is to convert the XML file to a YAML file. The TAML file is the result of a conversion from XML. 
 
 In this example, use the following YAML file instead.
 

--- a/docs/topics/mta-rn-known-issues-7-0-0.adoc
+++ b/docs/topics/mta-rn-known-issues-7-0-0.adoc
@@ -41,7 +41,7 @@ In {ProductShortName} 7.0.0, some XML custom rule files are converted to the new
 
 To resolve this issue, whenever a custom rule has a pattern ending in `.{\*}` and location `IMPORT`, the pattern `.{*}` can be changed to `{*}` and the location changed to `PACKAGE`.
 
-In the following example XML rule, note that the `when` condition is `javaclass references` ="javax.{*}"`. 
+In the following example XML rule, note that the `when` condition is `javaclass references ="javax.{*}"`. 
 
 If you amend this to `javaclass references="javax{*}"`, the rule converts correctly.
 

--- a/docs/topics/mta-rn-known-issues-7-0-0.adoc
+++ b/docs/topics/mta-rn-known-issues-7-0-0.adoc
@@ -37,7 +37,10 @@ This warning, appropriate for the first assessment, incorrectly reappears on sub
 
 .Custom rule for javax.* package import is not triggered when uploaded as an XML file
 
-In {ProductShortName} 7.0.0, the XML custom rule files are converted to the new YAML format during analysis. However, when using `javax-to-jakarta-package` as a custom rules file, it is not triggered after conversion
+In {ProductShortName} 7.0.0, some XML custom rule files are converted to the new YAML format during analysis. The root cause of this issue is that Java search patterns, which use `IMPORT` or `PACKAGE` as `location`, should not end in `.{*}` but just `{*}`. 
+
+To resolve this issue, whenever a custom rule has a pattern ending in `.{*}` and location one of `IMPORT` or `PACKAGE`, the pattern `.{*}` can be changed to `{*}`.
+
 
 
 In the following example XML rule, note that when condition is javaclass references ="javax.{*}"`.

--- a/docs/topics/mta-rn-known-issues-7-0-0.adoc
+++ b/docs/topics/mta-rn-known-issues-7-0-0.adoc
@@ -43,7 +43,6 @@ To resolve this issue, whenever a custom rule has a pattern ending in `.{*}` and
 
 In the following example XML rule, note that the `when` condition is `javaclass references` ="javax.{*}"`. 
 
-
 If you amend this to `javaclass references="javax{*}"`, the rule converts correctly.
 
 

--- a/docs/topics/mta-rn-known-issues-7-0-0.adoc
+++ b/docs/topics/mta-rn-known-issues-7-0-0.adoc
@@ -37,7 +37,7 @@ This warning, appropriate for the first assessment, incorrectly reappears on sub
 
 .Custom rule for javax.* package import is not triggered when uploaded as an XML file
 
-In {ProductShortName} 7.0.0, the XML custom rule files are converted to the new YAML format during analysis. However, when a `javax.\*` package import is not triggered when uploaded as an XML file.
+In {ProductShortName} 7.0.0, the XML custom rule files are converted to the new YAML format during analysis. However, when using `javax-to-jakarta-package` as a custom rules file, it is not triggered after conversion
 
 For example, when using `javax-package-custom-target.windup.xml` as a custom rules file, it is not triggered after conversion.
 

--- a/docs/topics/mta-rn-known-issues-7-0-0.adoc
+++ b/docs/topics/mta-rn-known-issues-7-0-0.adoc
@@ -37,7 +37,7 @@ This warning, appropriate for the first assessment, incorrectly reappears on sub
 
 .Custom rule for javax.{*} package import is not triggered when uploaded as an XML file
 
-In {ProductShortName} 7.0.0, some XML custom rule files are converted to the new YAML format during analysis. The root cause of this issue is Java search patterns that use `IMPORT` as `location`, should not end in `.{\*}` but `{\*}`. 
+In {ProductShortName} 7.0.0, some XML custom rule files are converted to the new YAML format during analysis. The root cause of this issue is Java search patterns that use `IMPORT` as `location`, should not end in `.{\*}` but `{\*}`. link:https://issues.redhat.com/browse/MTA-2000[MTA-2000]
 
 To resolve this issue, whenever a custom rule has a pattern ending in `.{*}` and location `IMPORT`, the pattern `.{*}` can be changed to `{*}` and the location changed to `PACKAGE`.
 

--- a/docs/topics/mta-rn-known-issues-7-0-0.adoc
+++ b/docs/topics/mta-rn-known-issues-7-0-0.adoc
@@ -40,7 +40,7 @@ This warning, appropriate for the first assessment, incorrectly reappears on sub
 In {ProductShortName} 7.0.0, the XML custom rule files are converted to the new YAML format during analysis. However, when using `javax-to-jakarta-package` as a custom rules file, it is not triggered after conversion
 
 
-.To view the javax-package-custom-target.windup.xml, click (here).
+.To view the javax-package-custom-target.windup.xml, click here.
 [%collapsible%closed]
 ====
 [source,xml]

--- a/docs/topics/mta-rn-known-issues-7-0-0.adoc
+++ b/docs/topics/mta-rn-known-issues-7-0-0.adoc
@@ -78,7 +78,7 @@ In {ProductShortName} 7.0.0, the XML custom rule files are converted to the new 
 ----
 ====
 
-The suggested workaround is to convert the XML file to a YAML file. The TAML file is the result of a conversion from XML. 
+The suggested workaround is to use the following YAML file instead. The YAML file is the result of a conversion from XML. 
 
 In this example, use the following YAML file instead.
 

--- a/docs/topics/mta-rn-known-issues-7-0-0.adoc
+++ b/docs/topics/mta-rn-known-issues-7-0-0.adoc
@@ -40,6 +40,11 @@ This warning, appropriate for the first assessment, incorrectly reappears on sub
 In {ProductShortName} 7.0.0, the XML custom rule files are converted to the new YAML format during analysis. However, when using `javax-to-jakarta-package` as a custom rules file, it is not triggered after conversion
 
 
+In the following example XML rule, note that when condition is javaclass references ="javax.{*}"`.
+
+If you amend this to `javaclass references="javax{*}"`, the rule converts correctly.
+
+
 .To view the javax-package-custom-target.windup.xml, click here.
 [%collapsible%closed]
 ====

--- a/docs/topics/mta-rn-known-issues-7-0-0.adoc
+++ b/docs/topics/mta-rn-known-issues-7-0-0.adoc
@@ -35,6 +35,82 @@ The system repeatedly shows a warning message about overriding an inherited asse
 
 This warning, appropriate for the first assessment, incorrectly reappears on subsequent reassessments, suggesting that the application is still inheriting its assessment, even after it has been overridden. link:https://issues.redhat.com/browse/MTA-1825[MTA-1825]
 
+.Custom rule for javax.* package import is not triggered when uploaded as an XML file
+
+In {ProductShortName} 7.0.0, the XML custom rule files are converted to the new YAML format during analysis. However, when a `javax.\*` package import is not triggered when uploaded as an XML file.
+
+For example, when using `javax-package-custom-target.windup.xml` as a custom rules file, it is not triggered after conversion.
+
+.To view the javax-package-custom-target.windup.xml, click (here).
+[%collapsible%closed]
+====
+[source,xml]
+----
+<?xml version="1.0"?>
+<ruleset xmlns="http://windup.jboss.org/schema/jboss-ruleset" id="javax-package"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://windup.jboss.org/schema/jboss-ruleset http://windup.jboss.org/schema/jboss-ruleset/windup-jboss-ruleset.xsd">
+    <metadata>
+        <description>
+            This ruleset evaluates whether a custom target can be used within a custom rule
+        </description>
+        <dependencies>
+            <addon id="org.jboss.windup.rules,windup-rules-javaee,3.0.0.Final" />
+            <addon id="org.jboss.windup.rules,windup-rules-java,3.0.0.Final" />
+        </dependencies>
+        <targetTechnology id="phil" versionRange="[7,8)" />
+    </metadata>
+    <rules>
+        <rule id="javax-package-custom-target-00001">
+            <when>
+                <javaclass references="javax.{*}">
+                    <location>IMPORT</location>
+                </javaclass>
+            </when>
+            <perform>
+                <hint title="CUSTOM RULE for javax.* package import" effort="1" category-id="potential">
+                    <message>`javax.*` packages must be renamed to `jakarta.*` for Jakarta EE9 compatibility.</message>
+                    <link title="Renamed Packages" href="https://github.com/wildfly-extras/batavia/blob/master/impl/ecl/src/main/resources/org/wildfly/extras/transformer/eclipse/jakarta-renames.properties"/>
+                </hint>
+            </perform>
+        </rule>
+    </rules>
+</ruleset>
+----
+====
+
+The suggested workaround is to convert the XML file to a YAML file
+
+In this example, use the following YAML file instead.
+
+.To view the 01-javax-package-custom-target.windup.yaml, click (here).
+[%collapsible%closed]
+====
+[source,xml]
+----
+- category: potential
+  customVariables: []
+  description: CUSTOM RULE for javax.* package import
+  effort: 1
+  labels:
+  - konveyor.io/target=phil7
+  - konveyor.io/target=phil
+  - konveyor.io/source
+  links:
+  - title: Renamed Packages
+    url: https://github.com/wildfly-extras/batavia/blob/master/impl/ecl/src/main/resources/org/wildfly/extras/transformer/eclipse/jakarta-renames.properties
+  message: '`javax.*` packages must be renamed to `jakarta.*` for Jakarta EE9 compatibility.'
+  ruleID: javax-package-custom-target-00001
+  when:
+    java.referenced:
+      location: package
+      pattern: javax*
+----
+====
+
+The file is the conversion result from XML to YAML format, with the line `location: IMPORT` was changed to `location: package`.
+
+
 For a complete list of all known issues in this release, see the list of link:https://issues.redhat.com/browse/MTA-2060?filter=12428334[Known Issues in Jira].
 
 // using filter - project in (MTA) AND type = Bug AND createdDate >= 2021-01-01 AND createdDate <= 2024-01-30 AND (resolutiondate > 2024-01-30 OR resolutiondate is EMPTY) AND Priority in (Blocker, Critical, Major) ORDER BY priority DESC, key DESC

--- a/docs/topics/mta-rn-known-issues-7-0-0.adoc
+++ b/docs/topics/mta-rn-known-issues-7-0-0.adoc
@@ -68,7 +68,7 @@ If you amend this to `javaclass references="javax{*}"`, the rule converts correc
     <rules>
         <rule id="javax-package-custom-target-00001">
             <when>
-                <javaclass references="javax.{*}">
+                <javaclass references="javax{*}">
                     <location>IMPORT</location>
                 </javaclass>
             </when>

--- a/docs/topics/mta-rn-known-issues-7-0-0.adoc
+++ b/docs/topics/mta-rn-known-issues-7-0-0.adoc
@@ -43,7 +43,8 @@ To resolve this issue, whenever a custom rule has a pattern ending in `.{*}` and
 
 
 
-In the following example XML rule, note that when condition is javaclass references ="javax.{*}"`.
+In the following example XML rule, note that the `when` condition is `javaclass references` ="javax.{*}"`. 
+
 
 If you amend this to `javaclass references="javax{*}"`, the rule converts correctly.
 

--- a/docs/topics/mta-rn-known-issues-7-0-0.adoc
+++ b/docs/topics/mta-rn-known-issues-7-0-0.adoc
@@ -37,7 +37,7 @@ This warning, appropriate for the first assessment, incorrectly reappears on sub
 
 .Custom rule for javax.{*} package import is not triggered when uploaded as an XML file
 
-In {ProductShortName} 7.0.0, some XML custom rule files are converted to the new YAML format during analysis. The root cause of this issue is that Java search patterns, which use `IMPORT` or `PACKAGE` as `location`, should not end in `.{*}` but just `{*}`. 
+In {ProductShortName} 7.0.0, some XML custom rule files are converted to the new YAML format during analysis. The root cause of this issue is Java search patterns that use `IMPORT` as `location`, should not end in `.{\*}` but `{\*}`. 
 
 To resolve this issue, whenever a custom rule has a pattern ending in `.{*}` and location `IMPORT`, the pattern `.{*}` can be changed to `{*}` and the location changed to `PACKAGE`.
 

--- a/docs/topics/mta-rn-known-issues-7-0-0.adoc
+++ b/docs/topics/mta-rn-known-issues-7-0-0.adoc
@@ -39,7 +39,7 @@ This warning, appropriate for the first assessment, incorrectly reappears on sub
 
 In {ProductShortName} 7.0.0, some XML custom rule files are converted to the new YAML format during analysis. The root cause of this issue is Java search patterns that use `IMPORT` as `location`, should not end in `.{\*}` but `{\*}`. link:https://issues.redhat.com/browse/MTA-2000[MTA-2000]
 
-To resolve this issue, whenever a custom rule has a pattern ending in `.{*}` and location `IMPORT`, the pattern `.{*}` can be changed to `{*}` and the location changed to `PACKAGE`.
+To resolve this issue, whenever a custom rule has a pattern ending in `.{\*}` and location `IMPORT`, the pattern `.{*}` can be changed to `{*}` and the location changed to `PACKAGE`.
 
 In the following example XML rule, note that the `when` condition is `javaclass references` ="javax.{*}"`. 
 

--- a/docs/topics/mta-rn-known-issues-7-0-0.adoc
+++ b/docs/topics/mta-rn-known-issues-7-0-0.adoc
@@ -86,32 +86,6 @@ If you amend this to `javaclass references="javax{*}"`, the rule converts correc
 
 The suggested workaround is to use the following YAML file instead. The YAML file is the result of a conversion from XML. 
 
-In this example, use the following YAML file instead.
-
-.To view the 01-javax-package-custom-target.windup.yaml, click here.
-[%collapsible%closed]
-====
-[source,yaml]
-----
-- category: potential
-  customVariables: []
-  description: CUSTOM RULE for javax.* package import
-  effort: 1
-  labels:
-  - konveyor.io/target=phil7
-  - konveyor.io/target=phil
-  - konveyor.io/source
-  links:
-  - title: Renamed Packages
-    url: https://github.com/wildfly-extras/batavia/blob/master/impl/ecl/src/main/resources/org/wildfly/extras/transformer/eclipse/jakarta-renames.properties
-  message: '`javax.*` packages must be renamed to `jakarta.*` for Jakarta EE9 compatibility.'
-  ruleID: javax-package-custom-target-00001
-  when:
-    java.referenced:
-      location: package
-      pattern: javax*
-----
-====
 
 The file is the conversion result from XML to YAML format, with the line `location: IMPORT` was changed to `location: package`.
 

--- a/docs/topics/mta-rn-known-issues-7-0-0.adoc
+++ b/docs/topics/mta-rn-known-issues-7-0-0.adoc
@@ -39,7 +39,6 @@ This warning, appropriate for the first assessment, incorrectly reappears on sub
 
 In {ProductShortName} 7.0.0, the XML custom rule files are converted to the new YAML format during analysis. However, when using `javax-to-jakarta-package` as a custom rules file, it is not triggered after conversion
 
-For example, when using `javax-package-custom-target.windup.xml` as a custom rules file, it is not triggered after conversion.
 
 .To view the javax-package-custom-target.windup.xml, click (here).
 [%collapsible%closed]

--- a/docs/topics/mta-rn-known-issues-7-0-0.adoc
+++ b/docs/topics/mta-rn-known-issues-7-0-0.adoc
@@ -37,7 +37,7 @@ This warning, appropriate for the first assessment, incorrectly reappears on sub
 
 .Custom rule for javax.{*} package import is not triggered when uploaded as an XML file
 
-In {ProductShortName} 7.0.0, some XML custom rule files are converted to the new YAML format during analysis. The root cause of this issue is Java search patterns that use `IMPORT` as `location`, should not end in `.{\*}` but should end in `{*}`. link:https://issues.redhat.com/browse/MTA-2000[MTA-2000]
+In {ProductShortName} 7.0.0, some XML custom rule files are converted to the new YAML format during analysis. The root cause is that Java search patterns that use `IMPORT` as `location` and end in `.{*}`, do not function as expected. link:https://issues.redhat.com/browse/MTA-2000[MTA-2000]
 
 To resolve this issue, whenever a custom rule has a pattern ending in `.{\*}` and location `IMPORT`, the pattern `.{*}` can be changed to `{*}` and the location changed to `PACKAGE`, as in the following example:.
 

--- a/docs/topics/mta-rn-known-issues-7-0-0.adoc
+++ b/docs/topics/mta-rn-known-issues-7-0-0.adoc
@@ -35,7 +35,7 @@ The system repeatedly shows a warning message about overriding an inherited asse
 
 This warning, appropriate for the first assessment, incorrectly reappears on subsequent reassessments, suggesting that the application is still inheriting its assessment, even after it has been overridden. link:https://issues.redhat.com/browse/MTA-1825[MTA-1825]
 
-.Custom rule for javax.* package import is not triggered when uploaded as an XML file
+.Custom rule for javax.{*} package import is not triggered when uploaded as an XML file
 
 In {ProductShortName} 7.0.0, some XML custom rule files are converted to the new YAML format during analysis. The root cause of this issue is that Java search patterns, which use `IMPORT` or `PACKAGE` as `location`, should not end in `.{*}` but just `{*}`. 
 

--- a/docs/topics/mta-rn-known-issues-7-0-0.adoc
+++ b/docs/topics/mta-rn-known-issues-7-0-0.adoc
@@ -39,7 +39,7 @@ This warning, appropriate for the first assessment, incorrectly reappears on sub
 
 In {ProductShortName} 7.0.0, some XML custom rule files are converted to the new YAML format during analysis. The root cause of this issue is that Java search patterns, which use `IMPORT` or `PACKAGE` as `location`, should not end in `.{*}` but just `{*}`. 
 
-To resolve this issue, whenever a custom rule has a pattern ending in `.{*}` and location one of `IMPORT` or `PACKAGE`, the pattern `.{*}` can be changed to `{*}`.
+To resolve this issue, whenever a custom rule has a pattern ending in `.{*}` and location `IMPORT`, the pattern `.{*}` can be changed to `{*}` and the location changed to `PACKAGE`.
 
 In the following example XML rule, note that the `when` condition is `javaclass references` ="javax.{*}"`. 
 

--- a/docs/topics/mta-rn-known-issues-7-0-0.adoc
+++ b/docs/topics/mta-rn-known-issues-7-0-0.adoc
@@ -86,7 +86,7 @@ In this example, use the following YAML file instead.
 .To view the 01-javax-package-custom-target.windup.yaml, click (here).
 [%collapsible%closed]
 ====
-[source,xml]
+[source,yaml]
 ----
 - category: potential
   customVariables: []

--- a/docs/topics/mta-rn-known-issues-7-0-0.adoc
+++ b/docs/topics/mta-rn-known-issues-7-0-0.adoc
@@ -43,7 +43,6 @@ To resolve this issue, whenever a custom rule has a pattern ending in `.{\*}` an
 
 In the following example XML rule, note that the `when` condition is `javaclass references ="javax.{*}"`. 
 
-If you amend this to `javaclass references="javax{*}"`, the rule converts correctly.
 
 
 .To view the javax-package-custom-target.windup.xml, click here.

--- a/docs/topics/mta-rn-known-issues-7-0-0.adoc
+++ b/docs/topics/mta-rn-known-issues-7-0-0.adoc
@@ -84,7 +84,6 @@ If you amend this to `javaclass references="javax{*}"`, the rule converts correc
 ----
 ====
 
-The suggested workaround is to use the following YAML file instead. The YAML file is the result of a conversion from XML. 
 
 
 For a complete list of all known issues in this release, see the list of link:https://issues.redhat.com/browse/MTA-2060?filter=12428334[Known Issues in Jira].

--- a/docs/topics/mta-rn-known-issues-7-0-0.adoc
+++ b/docs/topics/mta-rn-known-issues-7-0-0.adoc
@@ -41,8 +41,6 @@ In {ProductShortName} 7.0.0, some XML custom rule files are converted to the new
 
 To resolve this issue, whenever a custom rule has a pattern ending in `.{*}` and location one of `IMPORT` or `PACKAGE`, the pattern `.{*}` can be changed to `{*}`.
 
-
-
 In the following example XML rule, note that the `when` condition is `javaclass references` ="javax.{*}"`. 
 
 

--- a/docs/topics/mta-rn-known-issues-7-0-0.adoc
+++ b/docs/topics/mta-rn-known-issues-7-0-0.adoc
@@ -82,7 +82,7 @@ The suggested workaround is to use the following YAML file instead. The YAML fil
 
 In this example, use the following YAML file instead.
 
-.To view the 01-javax-package-custom-target.windup.yaml, click (here).
+.To view the 01-javax-package-custom-target.windup.yaml, click here.
 [%collapsible%closed]
 ====
 [source,yaml]

--- a/docs/topics/mta-rn-known-issues-7-0-0.adoc
+++ b/docs/topics/mta-rn-known-issues-7-0-0.adoc
@@ -69,7 +69,7 @@ If you amend this to `javaclass references="javax{*}"`, the rule converts correc
         <rule id="javax-package-custom-target-00001">
             <when>
                 <javaclass references="javax{*}">
-                    <location>IMPORT</location>
+                    <location>PACKAGE</location>
                 </javaclass>
             </when>
             <perform>

--- a/docs/topics/mta-rn-known-issues-7-0-0.adoc
+++ b/docs/topics/mta-rn-known-issues-7-0-0.adoc
@@ -41,7 +41,6 @@ In {ProductShortName} 7.0.0, some XML custom rule files are converted to the new
 
 To resolve this issue, whenever a custom rule has a pattern ending in `.{\*}` and location `IMPORT`, the pattern `.{*}` can be changed to `{*}` and the location changed to `PACKAGE`, as in the following example:.
 
-In the following example XML rule, note that the `when` condition is `javaclass references ="javax.{*}"`. 
 
 
 


### PR DESCRIPTION
### JIRA

* [MTA-2288](https://issues.redhat.com/browse/MTA-2288)

    * Added as Known issue to MTA 7.0.0
    * Collapsible blocks added `To view the javax-package-custom-target.windup.xml, click (here).` and `To view the 01-javax-package-custom-target.windup.yaml, click (here).`

### PREVIEW

* [Known issues-7-0-0_release-notes](https://deploy-preview-865--windup-documentation.netlify.app/docs/release-notes/master/#rn-known-issues-7-0-0_release-notes)