### PR TITLE
[MTA-2660] Updating installation instructions

### DIFF
--- a/docs/topics/mta-7-installing-web-console-on-openshift.adoc
+++ b/docs/topics/mta-7-installing-web-console-on-openshift.adoc
@@ -11,7 +11,7 @@ You can install the {ProductName} ({ProductShortName}) {WebName} on all Red Hat 
 
 IMPORTANT: To be able to create {ProductShortName} instances, you must first install the {ProductShortName} Operator.	
 
-The {ProductShortName} Operator is a structural layer that manages resources deployed on OpenShift (database, front end, back end) to automatically create an {ProductShortName} instance.
+The {ProductShortName} Operator is a structural layer that manages resources deployed on OpenShift, such as database, front end, and back end, to automatically create an {ProductShortName} instance.
 
 [id="openshift-persistent-volume-requirements_{context}"]
 == Persistent volume requirements

--- a/docs/topics/mta-7-installing-web-console-on-openshift.adoc
+++ b/docs/topics/mta-7-installing-web-console-on-openshift.adoc
@@ -9,6 +9,8 @@
 
 You can install the {ProductName} ({ProductShortName}) {WebName} on all Red Hat OpenShift cloud services and Red Hat OpenShift self-managed editions.
 
+IMPORTANT: To be able to create {ProductShortName} instances, you must first install the {ProductShortName} Operator.	
+
 The {ProductShortName} Operator is a structural layer that manages resources deployed on OpenShift (database, front end, back end) to automatically create an {ProductShortName} instance.
 
 [id="openshift-persistent-volume-requirements_{context}"]
@@ -52,7 +54,7 @@ To successfully deploy, the {ProductShortName} Operator requires 3 RWO persisten
 
 == Installing the {ProductName} Operator and the {WebName}
 
-You can install the {ProductName} ({ProductShortName}) and the {WebName} on Red Hat OpenShift versions 4.13-4.15 when you install the {ProductName} Operator.
+You can install the {ProductName} ({ProductShortName}) and the {WebName} on Red Hat OpenShift versions 4.13-4.15.
 
 .Prerequisites
 

--- a/docs/topics/mta-7-installing-web-console-on-openshift.adoc
+++ b/docs/topics/mta-7-installing-web-console-on-openshift.adoc
@@ -59,7 +59,7 @@ You can install the {ProductName} ({ProductShortName}) and the {WebName} on Red 
 .Prerequisites
 
 * 4 vCPUs, 8 GiB RAM, and 40 GiB persistent storage.
-* Any cloud services or self- hosted edition of Red Hat OpenShift on versions 4.13-4.15.
+* Any cloud services or self-hosted edition of Red Hat OpenShift on versions 4.13-4.15.
 * You must be logged in as a user with `cluster-admin` permissions.
 
 For more information, see link:https://access.redhat.com/support/policy/updates/openshift_operators[OpenShift Operator Life Cycles].

--- a/docs/topics/mta-7-installing-web-console-on-openshift.adoc
+++ b/docs/topics/mta-7-installing-web-console-on-openshift.adoc
@@ -7,7 +7,7 @@
 
 = Installing the {ProductName} {WebName}
 
-You can install the {ProductName} ({ProductShortName}) {WebName} on all cloud services and self-managed OpenShift editions.
+You can install the {ProductName} ({ProductShortName}) {WebName} on all Red Hat OpenShift cloud services and Red Hat OpenShift self-managed editions.
 
 The {ProductShortName} Operator is a structural layer that manages resources deployed on OpenShift (database, front end, back end) to automatically create an {ProductShortName} instance.
 
@@ -52,19 +52,19 @@ To successfully deploy, the {ProductShortName} Operator requires 3 RWO persisten
 
 == Installing the {ProductName} Operator and the {WebName}
 
-You can install the {ProductName} ({ProductShortName}) and the {WebName} on OpenShift versions 4.13-4.15 when you install the {ProductName} Operator.
+You can install the {ProductName} ({ProductShortName}) and the {WebName} on Red Hat OpenShift versions 4.13-4.15 when you install the {ProductName} Operator.
 
 .Prerequisites
 
 * 4 vCPUs, 8 GiB RAM, and 40 GiB persistent storage.
-* Any cloud services or self- hosted edition of OpenShift on versions 4.13-4.15.
+* Any cloud services or self- hosted edition of Red Hat OpenShift on versions 4.13-4.15.
 * You must be logged in as a user with `cluster-admin` permissions.
 
 For more information, see link:https://access.redhat.com/support/policy/updates/openshift_operators[OpenShift Operator Life Cycles].
 
 .Procedure
 
-. In the OpenShift web console, click *Operators → OperatorHub*.
+. In the Red Hat OpenShift web console, click *Operators → OperatorHub*.
 . Use the *Filter by keyword* field to search for *MTA*.
 . Click the *Migration Toolkit for Applications* Operator and then click *Install*.
 . On the *Install Operator* page, click *Install*.
@@ -181,7 +181,7 @@ spec:
 . When prompted, create a new password.
 
 [id="installing-mta-operator-in-disconnected-environment_{context}"]
-== Installing the {ProductName} Operator in a disconnected OpenShift environment
+== Installing the {ProductName} Operator in a disconnected Red Hat OpenShift environment
 
 You can install the {ProductShortName} Operator in a disconnected environment by following the instructions in link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.15/html/installing/disconnected-installation-mirroring#installing-mirroring-disconnected[generic procedure].
 

--- a/docs/topics/mta-7-installing-web-console-on-openshift.adoc
+++ b/docs/topics/mta-7-installing-web-console-on-openshift.adoc
@@ -7,9 +7,9 @@
 
 = Installing the {ProductName} {WebName}
 
-You can install the {ProductName} ({ProductShortName}) {WebName} as part of the process of installing the {ProductShortName} Operator on the OpenShift Container Platform.
+You can install the {ProductName} ({ProductShortName}) {WebName} on all cloud services and self-managed OpenShift editions.
 
-The {ProductShortName} Operator is a structural layer that manages resources deployed on Kubernetes (database, front end, back end) to automatically create an {ProductShortName} instance.
+The {ProductShortName} Operator is a structural layer that manages resources deployed on OpenShift (database, front end, back end) to automatically create an {ProductShortName} instance.
 
 [id="openshift-persistent-volume-requirements_{context}"]
 == Persistent volume requirements
@@ -52,19 +52,19 @@ To successfully deploy, the {ProductShortName} Operator requires 3 RWO persisten
 
 == Installing the {ProductName} Operator and the {WebName}
 
-You can install the {ProductName} ({ProductShortName}) and the {WebName} on OpenShift Container Platform versions 4.13-4.15 when you install the {ProductName} Operator.
+You can install the {ProductName} ({ProductShortName}) and the {WebName} on OpenShift versions 4.13-4.15 when you install the {ProductName} Operator.
 
 .Prerequisites
 
 * 4 vCPUs, 8 GiB RAM, and 40 GiB persistent storage.
-* OpenShift Container Platform 4.13-4.15 installed.
+* Any cloud services or self- hosted edition of OpenShift on versions 4.13-4.15.
 * You must be logged in as a user with `cluster-admin` permissions.
 
 For more information, see link:https://access.redhat.com/support/policy/updates/openshift_operators[OpenShift Operator Life Cycles].
 
 .Procedure
 
-. In the OpenShift Container Platform web console, click *Operators → OperatorHub*.
+. In the OpenShift web console, click *Operators → OperatorHub*.
 . Use the *Filter by keyword* field to search for *MTA*.
 . Click the *Migration Toolkit for Applications* Operator and then click *Install*.
 . On the *Install Operator* page, click *Install*.
@@ -181,7 +181,7 @@ spec:
 . When prompted, create a new password.
 
 [id="installing-mta-operator-in-disconnected-environment_{context}"]
-== Installing the {ProductName} Operator in a disconnected {ocp-short} environment
+== Installing the {ProductName} Operator in a disconnected OpenShift environment
 
 You can install the {ProductShortName} Operator in a disconnected environment by following the instructions in link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.15/html/installing/disconnected-installation-mirroring#installing-mirroring-disconnected[generic procedure].
 


### PR DESCRIPTION
### Goal:

Update MTA [Installation instructions](https://access.redhat.com/documentation/en-us/migration_toolkit_for_applications/7.0/html-single/user_interface_guide/index#mta-7-installing-web-console-on-openshift_user-interface-guide) to include all OpenShift editions, both [cloud](https://www.redhat.com/en/technologies/cloud-computing/openshift#cloud-services-editions) and [self managed](https://www.redhat.com/en/technologies/cloud-computing/openshift#self-managed).