### PR TITLE
MTA-3443: Issue with Podman installation instructions for 7.0

### DIFF
--- a/docs/topics/installing-cli-tool.adoc
+++ b/docs/topics/installing-cli-tool.adoc
@@ -67,7 +67,7 @@ Password: <***********>
 +
 [source,terminal]
 ----
-podman cp $(podman create registry.redhat.com/mta-toolkit/mta-mta-cli-rhel9:{ProductVersion}):/usr/local/bin/mta-cli ./
+podman cp $(podman create registry.redhat.io/mta/mta-rhel8-operator:{PodmanProductVersion}):/usr/local/bin ./
 ----
 +
 This command will copy the binary `PATH` for system-wide use.

--- a/docs/topics/templates/document-attributes.adoc
+++ b/docs/topics/templates/document-attributes.adoc
@@ -25,6 +25,7 @@ ifdef::mta[]
 :WebNameURL: user_interface_guide
 :WebConsoleBookName: {WebNameTitle} Guide
 :ProductVersion: 7.0.3
+:PodmanProductVersion: 7.0.3-7
 :PluginName: MTA plugin
 // :MavenProductVersion: 7.0.0.GA-redhat-00001
 :ProductDistributionVersion: 7.0.3.GA-redhat


### PR DESCRIPTION
### Jira 

* [MTA-3443](https://issues.redhat.com/browse/MTA-3443)

I have been struggling with the Podman instructions in the documentation. I checked the registry and have changed from:
```
podman cp $(podman create registry.redhat.com/mta-toolkit/mta-mta-cli-rhel9:{ProductVersion}):/usr/local/bin/mta-cli ./
```
to
```
podman cp $(podman create registry.redhat.io/mta/mta-rhel8-operator:{PodmanProductVersion}):/usr/local/bin ./
```

This change appears to work. However we will need to update the attributes for 7.1 to ensure the version is always updated. I have pointed the current version to `7.0.3-7`